### PR TITLE
Fix filter by column with date type

### DIFF
--- a/src/inputs/MRT_FilterTextField.tsx
+++ b/src/inputs/MRT_FilterTextField.tsx
@@ -73,14 +73,15 @@ export const MRT_FilterTextField: FC<Props> = ({
 
   const handleChangeDebounced = useCallback(
     debounce((event: ChangeEvent<HTMLInputElement>) => {
+      let value = textFieldProps.type === 'date' ? new Date(event.target.value) : event.target.value
       if (inputIndex !== undefined) {
-        column.setFilterValue((old: [string, string]) => {
+        column.setFilterValue((old: [string, string | Date]) => {
           const newFilterValues = old ?? ['', ''];
-          newFilterValues[inputIndex] = event.target.value;
+          newFilterValues[inputIndex] = value;
           return newFilterValues;
         });
       } else {
-        column.setFilterValue(event.target.value ?? undefined);
+        column.setFilterValue(value ?? undefined);
       }
     }, 200),
     [],

--- a/stories/features/Filtering.stories.tsx
+++ b/stories/features/Filtering.stories.tsx
@@ -28,6 +28,16 @@ const columns: MRT_ColumnDef<typeof data[0]>[] = [
     accessorKey: 'age',
   },
   {
+    Cell: ({ cell }) => cell.getValue<Date>().toLocaleDateString(), //transform data to readable format for cell render
+    accessorFn: (row) => new Date(row.birthDate), //transform data before processing so sorting works
+    accessorKey: 'birthDate',
+    header: 'Birth Date',
+    muiTableHeadCellFilterTextFieldProps: {
+      type: 'date',
+    },
+    sortingFn: 'datetime',
+  },
+  {
     header: 'Gender',
     accessorKey: 'gender',
   },
@@ -45,6 +55,7 @@ const data = [...Array(100)].map(() => ({
   firstName: faker.name.firstName(),
   lastName: faker.name.lastName(),
   age: faker.datatype.number(100),
+  birthDate: faker.date.birthdate({min:1990, max: 2020}),
   gender: faker.name.gender(true),
   address: faker.address.streetAddress(),
   state: faker.address.state(),


### PR DESCRIPTION
Date filtering did not work correctly.
Column setup example
```
{
    Cell: ({ cell }) => cell.getValue<Date>().toLocaleDateString(),
    accessorFn: (row) => new Date(row.birthDate),
    accessorKey: 'birthDate',
    header: 'Birth Date',
    muiTableHeadCellFilterTextFieldProps: {
      type: 'date',
    },
    sortingFn: 'datetime',
}
```


The problem was that the date picker control returned a string instead of a date.