### PR TITLE
fix: correctly set initial value for multi-select fields

### DIFF
--- a/src/inputs/MRT_FilterTextField.tsx
+++ b/src/inputs/MRT_FilterTextField.tsx
@@ -1,11 +1,3 @@
-import React, {
-  ChangeEvent,
-  FC,
-  MouseEvent,
-  useCallback,
-  useEffect,
-  useState,
-} from 'react';
 import {
   Box,
   Checkbox,
@@ -18,8 +10,16 @@ import {
   TextFieldProps,
   Tooltip,
 } from '@mui/material';
-import { MRT_FilterOptionMenu } from '../menus/MRT_FilterOptionMenu';
+import React, {
+  ChangeEvent,
+  FC,
+  MouseEvent,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
 import type { MRT_Header, MRT_TableInstance } from '..';
+import { MRT_FilterOptionMenu } from '../menus/MRT_FilterOptionMenu';
 
 interface Props {
   header: MRT_Header;
@@ -171,8 +171,8 @@ export const MRT_FilterTextField: FC<Props> = ({
   };
 
   useEffect(() => {
-    setFilterValue(isMultiSelectFilter ? [] : '');
-  }, [columnDef._filterFn, isMultiSelectFilter]);
+    handleClear();
+  }, [columnDef._filterFn]);
 
   if (columnDef.Filter) {
     return <>{columnDef.Filter?.({ column, header, table })}</>;

--- a/src/inputs/MRT_FilterTextField.tsx
+++ b/src/inputs/MRT_FilterTextField.tsx
@@ -171,8 +171,8 @@ export const MRT_FilterTextField: FC<Props> = ({
   };
 
   useEffect(() => {
-    setFilterValue('');
-  }, [columnDef._filterFn]);
+    setFilterValue(isMultiSelectFilter ? [] : '');
+  }, [columnDef._filterFn, isMultiSelectFilter]);
 
   if (columnDef.Filter) {
     return <>{columnDef.Filter?.({ column, header, table })}</>;


### PR DESCRIPTION
Fixes #57, though we may want to call `handleClear`? Or at least derive the initial value somewhere in the component and reuse that to avoid using `[]` or `''` as much throughout the component.