### PR TITLE
Update table-instance-apis.mdx

### DIFF
--- a/material-react-table-docs/pages/docs/api/table-instance-apis.mdx
+++ b/material-react-table-docs/pages/docs/api/table-instance-apis.mdx
@@ -20,9 +20,9 @@ import SourceCode from '../../../components/prop-tables/TableInstanceAPIsSource'
 
 ## Table Instance APIs
 
-Internally, Material React Table uses the `useReactTable` hook from TanStack Table to create a table instance that handles a majority of all the logic, events, and state for the table.
+Internally, Material React Table uses the `useReactTable` hook from TanStack Table to create a table instance that handles a majority of the logic and events and the state for the table.
 
-You can access this table instance yourself by either setting up a `tableInstanceRef`, or by consuming a `table` param from many of the callback functions in many of the props.
+You can access this table instance yourself by either setting up a `tableInstanceRef` or by consuming a `table` param from many of the callback functions in many of the props.
 
 ```jsx
 const tableInstanceRef = useRef(null);


### PR DESCRIPTION
One thing I wanted to draw your attention to was in line, "You can access this table instance yourself by either setting up a tableInstanceRef, or by consuming a table param from many of the callback functions in many of the props." Just wanted to make sure that "many" in this sentence is correct and shouldn't be "any?" I didn't change anything because I figured it was probably correct as is, but thought I'd bring it up, just in case.