### PR TITLE
feat: add no data customization

### DIFF
--- a/material-react-table-docs/components/prop-tables/rootProps.ts
+++ b/material-react-table-docs/components/prop-tables/rootProps.ts
@@ -1626,6 +1626,16 @@ export const rootProps: PropRow[] = [
     type: 'ReactNode | ({ table }) => ReactNode',
   },
   {
+    propName: 'renderCustomNoData',
+    defaultValue: '',
+    description: '',
+    link: '',
+    linkText: '',
+    required: false,
+    source: '',
+    type: '({ table }) => ReactNode',
+  },
+  {
     propName: 'renderColumnActionsMenuItems',
     defaultValue: '',
     description: '',

--- a/src/MaterialReactTable.tsx
+++ b/src/MaterialReactTable.tsx
@@ -952,6 +952,11 @@ export type MaterialReactTableProps<TData extends Record<string, any> = {}> =
     positionPagination?: 'bottom' | 'top' | 'both';
     positionToolbarAlertBanner?: 'bottom' | 'top' | 'none';
     positionToolbarDropZone?: 'bottom' | 'top' | 'none' | 'both';
+    renderCustomNoData?: ({
+      table,
+    }: {
+      table: MRT_TableInstance<TData>;
+    }) => ReactNode;
     renderBottomToolbar?:
       | ReactNode
       | (({ table }: { table: MRT_TableInstance<TData> }) => ReactNode);

--- a/src/body/MRT_TableBody.tsx
+++ b/src/body/MRT_TableBody.tsx
@@ -27,6 +27,7 @@ export const MRT_TableBody: FC<Props> = ({ table }) => {
       muiTableBodyProps,
       virtualizerInstanceRef,
       virtualizerProps,
+      renderCustomNoData,
     },
     refs: { tableContainerRef, tablePaperRef },
   } = table;
@@ -120,24 +121,28 @@ export const MRT_TableBody: FC<Props> = ({ table }) => {
   return (
     <TableBody {...tableBodyProps}>
       {!rows.length ? (
-        <tr>
-          <td colSpan={table.getVisibleLeafColumns().length}>
-            <Typography
-              sx={{
-                color: 'text.secondary',
-                fontStyle: 'italic',
-                maxWidth: `min(100vw, ${tablePaperRef.current?.clientWidth}px)`,
-                py: '2rem',
-                textAlign: 'center',
-                width: '100%',
-              }}
-            >
-              {globalFilter || columnFilters.length
-                ? localization.noResultsFound
-                : localization.noRecordsToDisplay}
-            </Typography>
-          </td>
-        </tr>
+        renderCustomNoData ? (
+          renderCustomNoData({ table })
+        ) : (
+          <tr>
+            <td colSpan={table.getVisibleLeafColumns().length}>
+              <Typography
+                sx={{
+                  color: 'text.secondary',
+                  fontStyle: 'italic',
+                  maxWidth: `min(100vw, ${tablePaperRef.current?.clientWidth}px)`,
+                  py: '2rem',
+                  textAlign: 'center',
+                  width: '100%',
+                }}
+              >
+                {globalFilter || columnFilters.length
+                  ? localization.noResultsFound
+                  : localization.noRecordsToDisplay}
+              </Typography>
+            </td>
+          </tr>
+        )
       ) : (
         <>
           {enableRowVirtualization && paddingTop > 0 && (

--- a/stories/styling/TableBodyRowStyles.stories.tsx
+++ b/stories/styling/TableBodyRowStyles.stories.tsx
@@ -5,6 +5,7 @@ import MaterialReactTable, {
   MRT_ColumnDef,
 } from '../../src';
 import { faker } from '@faker-js/faker';
+import { Box, Typography } from '@mui/material';
 
 const meta: Meta = {
   title: 'Styling/Style Table Body Rows',
@@ -90,5 +91,21 @@ export const ConditionallyStyleMuiTableRow: Story<
         fontStyle: 'italic',
       },
     })}
+  />
+);
+
+export const renderCustomNoData: Story<MaterialReactTableProps> = () => (
+  <MaterialReactTable
+    columns={columns}
+    data={[]}
+    renderCustomNoData={({ table }) => (
+      <tr>
+        <td colSpan={table.getVisibleLeafColumns().length}>
+          <Box p={2}>
+            <Typography>🧐 Hmmm there's no data here ∅</Typography>
+          </Box>
+        </td>
+      </tr>
+    )}
   />
 );


### PR DESCRIPTION
This quick PR adds the ability to style the the table body when there are no rows.
Happy to adjust the PR as required @KevinVandy 😄 