### PR TITLE
Avoid exception when input is a select

### DIFF
--- a/src/body/MRT_TableBodyCell.tsx
+++ b/src/body/MRT_TableBodyCell.tsx
@@ -148,7 +148,7 @@ export const MRT_TableBodyCell: FC<Props> = ({
         const textField = editInputRefs.current[column.id];
         if (textField) {
           textField.focus();
-          textField.select();
+          textField.select?.();
         }
       });
     }


### PR DESCRIPTION
As [TextField API](https://mui.com/material-ui/api/text-field/#props) said, we can use as a Select using the boolean prop `select`. The Select element has not the `.select()` method as Input. So, material-react-table is throwing an exception:


<img width="365" alt="image" src="https://user-images.githubusercontent.com/2332886/198854438-4bf6959c-a479-4ead-bea8-0aa14320a142.png">


