### PR TITLE
Fixed global filter when manual paginating

### DIFF
--- a/packages/material-react-table/src/body/MRT_TableBody.tsx
+++ b/packages/material-react-table/src/body/MRT_TableBody.tsx
@@ -36,6 +36,7 @@ export const MRT_TableBody: FC<Props> = ({
       layoutMode,
       localization,
       manualFiltering,
+      manualPagination,
       manualSorting,
       memoMode,
       muiTableBodyProps,
@@ -75,7 +76,7 @@ export const MRT_TableBody: FC<Props> = ({
       const rankedRows = getPrePaginationRowModel().rows.sort((a, b) =>
         rankGlobalFuzzy(a, b),
       );
-      if (enablePagination) {
+      if (enablePagination  && !manualPagination) {
         const start = pagination.pageIndex * pagination.pageSize;
         return rankedRows.slice(start, start + pagination.pageSize);
       }


### PR DESCRIPTION
Problem:
If `manualPagination` is `true`, the current `rows` function for the `TableBody` component improperly performs a `slice` on the search results.

Proposed fix:
The user is already handling pagination manually, there is no need to perform an additional slice to accommodate the default pagination logic.