### PR TITLE
Fix sorting issue with memo and virtualization

### DIFF
--- a/packages/material-react-table/src/body/MRT_TableBodyRow.tsx
+++ b/packages/material-react-table/src/body/MRT_TableBodyRow.tsx
@@ -165,5 +165,5 @@ export const MRT_TableBodyRow: FC<Props> = ({
 
 export const Memo_MRT_TableBodyRow = memo(
   MRT_TableBodyRow,
-  (prev, next) => prev.row === next.row,
+  (prev, next) => (prev.row === next.row && prev.rowIndex === next.rowIndex),
 );


### PR DESCRIPTION
Problem:
When using `memoMode = "row"` and table virtualization, when sorting a column, row positioning may not be correctly updated if the row existed (in DOM?) _before_ AND _after_ the sort.

Fix:
Add additional check to `propsAreEqual` function for `Memo_MRT_TableBodyRow` to check if the row index has changed.