### PR TITLE
Allow extending core table features

### DIFF
--- a/apps/material-react-table-docs/components/prop-tables/rootProps.ts
+++ b/apps/material-react-table-docs/components/prop-tables/rootProps.ts
@@ -1895,4 +1895,14 @@ export const rootProps: PropRow[] = [
     source: 'MRT',
     type: 'MutableRefObject<Virtualizer | null>',
   },
+  {
+    propName: 'tableFeatures',
+    defaultValue: '',
+    description: '',
+    link: '',
+    linkText: '',
+    required: false,
+    source: '',
+    type: 'Array<(table: MRT_TableInstance<any>) => any>',
+  },
 ];

--- a/packages/material-react-table/src/MaterialReactTable.tsx
+++ b/packages/material-react-table/src/MaterialReactTable.tsx
@@ -567,6 +567,11 @@ export type MRT_DisplayColumnIds =
   | 'mrt-row-numbers'
   | 'mrt-row-select';
 
+export type MRT_CreateTableFeature<
+  TData extends Record<string, any> = {},
+  TFeature = any,
+> = (table: MRT_TableInstance<TData>) => TFeature;
+
 /**
  * `columns` and `data` props are the only required props, but there are over 150 other optional props.
  *
@@ -949,6 +954,10 @@ export type MaterialReactTableProps<TData extends Record<string, any> = {}> =
      * @deprecated Use `rowVirtualizerProps` instead
      */
     virtualizerProps?: any;
+    /**
+     * Sequence of features important any dependent feature must be defined first
+     */
+    tableFeatures?: Array<MRT_CreateTableFeature<TData>>;
   };
 
 const MaterialReactTable = <TData extends Record<string, any> = {}>({

--- a/packages/material-react-table/src/table/MRT_TableRoot.tsx
+++ b/packages/material-react-table/src/table/MRT_TableRoot.tsx
@@ -332,6 +332,12 @@ export const MRT_TableRoot: any = <TData extends Record<string, any> = {}>(
       props.onShowToolbarDropZoneChange ?? setShowToolbarDropZone,
   } as MRT_TableInstance<TData>;
 
+  if (props.tableFeatures) {
+    props.tableFeatures.forEach(feature => {
+      Object.assign(table, feature(table));
+    });
+  }
+
   if (props.tableInstanceRef) {
     props.tableInstanceRef.current = table;
   }


### PR DESCRIPTION
Consumer can attach more feature to existing table instance, which was not possible through ref table instance after re-render it is getting initialised again. In this PR, with each re-render it will assign extended features to the created table instance again, which will be available across through ref & props.

e.g. 
```jsx
function advanceSearchFeature<TData extends Record<string, any> = {}>(table: MRT_TableInstance<TData>) {
  return {
    getAdvanceSearchFilters: () => table.getState().advanceFilters;
  }
}

<MaterialReactTable 
  ...
  state={{ advanceFilters }} //manage your own state, pass it back to the table (optional)
/>

// Other place in consumer
const handleAdvanceSearch = () => {
  const filters = tableInstanceRef.current.getAdvanceSearchFilters();
  ...
};
```