### PR TITLE
Add examples for row actions

### DIFF
--- a/apps/material-react-table-docs/examples/row-actions-buttons/index.tsx
+++ b/apps/material-react-table-docs/examples/row-actions-buttons/index.tsx
@@ -10,7 +10,7 @@ const ExampleTable = () => {
       Component={Example}
       javaScriptCode={JS}
       typeScriptCode={TS}
-      tableId="row-actions-menu-items"
+      tableId="row-actions-buttons"
     />
   );
 };

--- a/apps/material-react-table-docs/examples/row-actions-buttons/index.tsx
+++ b/apps/material-react-table-docs/examples/row-actions-buttons/index.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { SourceCodeSnippet } from '../../components/mdx/SourceCodeSnippet';
+import Example from './sandbox/src/TS';
+const JS = require('!!raw-loader!./sandbox/src/JS.js').default;
+const TS = require('!!raw-loader!./sandbox/src/TS.tsx').default;
+
+const ExampleTable = () => {
+  return (
+    <SourceCodeSnippet
+      Component={Example}
+      javaScriptCode={JS}
+      typeScriptCode={TS}
+      tableId="row-actions-menu-items"
+    />
+  );
+};
+
+export default ExampleTable;

--- a/apps/material-react-table-docs/examples/row-actions-buttons/sandbox/.gitignore
+++ b/apps/material-react-table-docs/examples/row-actions-buttons/sandbox/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.DS_Store
+dist
+dist-ssr
+*.local

--- a/apps/material-react-table-docs/examples/row-actions-buttons/sandbox/README.md
+++ b/apps/material-react-table-docs/examples/row-actions-buttons/sandbox/README.md
@@ -1,0 +1,6 @@
+# Example
+
+To run this example:
+
+- `npm install` or `yarn`
+- `npm run start` or `yarn start`

--- a/apps/material-react-table-docs/examples/row-actions-buttons/sandbox/index.html
+++ b/apps/material-react-table-docs/examples/row-actions-buttons/sandbox/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Material React Table Example</title>
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/material-react-table-docs/examples/row-actions-buttons/sandbox/package.json
+++ b/apps/material-react-table-docs/examples/row-actions-buttons/sandbox/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "material-react-table-example-minimal",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite --port 3001",
+    "build": "vite build",
+    "serve": "vite preview",
+    "start": "vite"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.10.5",
+    "@emotion/styled": "^11.10.5",
+    "@mui/icons-material": "^5.11.0",
+    "@mui/material": "^5.11.4",
+    "material-react-table": "latest",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.26",
+    "@types/react-dom": "^18.0.10",
+    "@vitejs/plugin-react": "^3.0.1",
+    "typescript": "^4.9.4",
+    "vite": "^4.0.4"
+  }
+}

--- a/apps/material-react-table-docs/examples/row-actions-buttons/sandbox/src/JS.js
+++ b/apps/material-react-table-docs/examples/row-actions-buttons/sandbox/src/JS.js
@@ -1,0 +1,55 @@
+import React, { useMemo } from 'react';
+import MaterialReactTable from 'material-react-table';
+import { data } from './makeData';
+import { Box, IconButton } from '@mui/material';
+import { Edit as EditIcon, Delete as DeleteIcon } from '@mui/icons-material';
+
+export const Example = () => {
+  const columns = useMemo(
+    //column definitions...
+    () => [
+      {
+        accessorKey: 'firstName',
+        header: 'First Name',
+      },
+      {
+        accessorKey: 'lastName',
+        header: 'Last Name',
+      },
+      {
+        accessorKey: 'address',
+        header: 'Address',
+      },
+      {
+        accessorKey: 'city',
+        header: 'City',
+      },
+      {
+        accessorKey: 'state',
+        header: 'State',
+      },
+    ],
+    [],
+    //end
+  );
+
+  return (
+    <MaterialReactTable
+      columns={columns}
+      data={data}
+      enableRowActions
+      renderRowActions={({ row }) => (
+        <Box>
+          <IconButton onClick={() => console.info('Edit')}>
+            <EditIcon />
+          </IconButton>
+          <IconButton onClick={() => console.info('Delete')}>
+            <DeleteIcon />
+          </IconButton>
+        </Box>
+      )}
+    />
+  );
+};
+
+export default Example;

--- a/apps/material-react-table-docs/examples/row-actions-buttons/sandbox/src/TS.tsx
+++ b/apps/material-react-table-docs/examples/row-actions-buttons/sandbox/src/TS.tsx
@@ -1,0 +1,55 @@
+import React, { useMemo } from 'react';
+import MaterialReactTable, { type MRT_ColumnDef } from 'material-react-table';
+import { data, type Person } from './makeData';
+import { Box, IconButton } from '@mui/material';
+import { Edit as EditIcon, Delete as DeleteIcon } from '@mui/icons-material';
+
+export const Example = () => {
+  const columns = useMemo<MRT_ColumnDef<Person>[]>(
+    //column definitions...
+    () => [
+      {
+        accessorKey: 'firstName',
+        header: 'First Name',
+      },
+      {
+        accessorKey: 'lastName',
+        header: 'Last Name',
+      },
+      {
+        accessorKey: 'address',
+        header: 'Address',
+      },
+      {
+        accessorKey: 'city',
+        header: 'City',
+      },
+      {
+        accessorKey: 'state',
+        header: 'State',
+      },
+    ],
+    [],
+    //end
+  );
+
+  return (
+    <MaterialReactTable
+      columns={columns}
+      data={data}
+      enableRowActions
+      renderRowActions={({ row }) => (
+        <Box>
+          <IconButton onClick={() => console.info('Edit')}>
+            <EditIcon />
+          </IconButton>
+          <IconButton onClick={() => console.info('Delete')}>
+            <DeleteIcon />
+          </IconButton>
+        </Box>
+      )}
+    />
+  );
+};
+
+export default Example;

--- a/apps/material-react-table-docs/examples/row-actions-buttons/sandbox/src/main.tsx
+++ b/apps/material-react-table-docs/examples/row-actions-buttons/sandbox/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import Example from './TS';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <Example />
+  </React.StrictMode>,
+);

--- a/apps/material-react-table-docs/examples/row-actions-buttons/sandbox/src/makeData.ts
+++ b/apps/material-react-table-docs/examples/row-actions-buttons/sandbox/src/makeData.ts
@@ -1,0 +1,45 @@
+export type Person = {
+  firstName: string;
+  lastName: string;
+  address: string;
+  city: string;
+  state: string;
+};
+
+export const data = [
+  {
+    firstName: 'Dylan',
+    lastName: 'Murray',
+    address: '261 Erdman Ford',
+    city: 'East Daphne',
+    state: 'Kentucky',
+  },
+  {
+    firstName: 'Raquel',
+    lastName: 'Kohler',
+    address: '769 Dominic Grove',
+    city: 'Columbus',
+    state: 'Ohio',
+  },
+  {
+    firstName: 'Ervin',
+    lastName: 'Reinger',
+    address: '566 Brakus Inlet',
+    city: 'South Linda',
+    state: 'West Virginia',
+  },
+  {
+    firstName: 'Brittany',
+    lastName: 'McCullough',
+    address: '722 Emie Stream',
+    city: 'Lincoln',
+    state: 'Nebraska',
+  },
+  {
+    firstName: 'Branson',
+    lastName: 'Frami',
+    address: '32188 Larkin Turnpike',
+    city: 'Charleston',
+    state: 'South Carolina',
+  },
+];

--- a/apps/material-react-table-docs/examples/row-actions-buttons/sandbox/src/vite.env.d.ts
+++ b/apps/material-react-table-docs/examples/row-actions-buttons/sandbox/src/vite.env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/material-react-table-docs/examples/row-actions-buttons/sandbox/tsconfig.json
+++ b/apps/material-react-table-docs/examples/row-actions-buttons/sandbox/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ESNext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ]
+}

--- a/apps/material-react-table-docs/examples/row-actions-buttons/sandbox/tsconfig.node.json
+++ b/apps/material-react-table-docs/examples/row-actions-buttons/sandbox/tsconfig.node.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node"
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apps/material-react-table-docs/examples/row-actions-buttons/sandbox/vite.config.js
+++ b/apps/material-react-table-docs/examples/row-actions-buttons/sandbox/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+});

--- a/apps/material-react-table-docs/examples/row-actions-menu-items/index.tsx
+++ b/apps/material-react-table-docs/examples/row-actions-menu-items/index.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { SourceCodeSnippet } from '../../components/mdx/SourceCodeSnippet';
+import Example from './sandbox/src/TS';
+const JS = require('!!raw-loader!./sandbox/src/JS.js').default;
+const TS = require('!!raw-loader!./sandbox/src/TS.tsx').default;
+
+const ExampleTable = () => {
+  return (
+    <SourceCodeSnippet
+      Component={Example}
+      javaScriptCode={JS}
+      typeScriptCode={TS}
+      tableId="row-actions-menu-items"
+    />
+  );
+};
+
+export default ExampleTable;

--- a/apps/material-react-table-docs/examples/row-actions-menu-items/sandbox/.gitignore
+++ b/apps/material-react-table-docs/examples/row-actions-menu-items/sandbox/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.DS_Store
+dist
+dist-ssr
+*.local

--- a/apps/material-react-table-docs/examples/row-actions-menu-items/sandbox/README.md
+++ b/apps/material-react-table-docs/examples/row-actions-menu-items/sandbox/README.md
@@ -1,0 +1,6 @@
+# Example
+
+To run this example:
+
+- `npm install` or `yarn`
+- `npm run start` or `yarn start`

--- a/apps/material-react-table-docs/examples/row-actions-menu-items/sandbox/index.html
+++ b/apps/material-react-table-docs/examples/row-actions-menu-items/sandbox/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Material React Table Example</title>
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/material-react-table-docs/examples/row-actions-menu-items/sandbox/package.json
+++ b/apps/material-react-table-docs/examples/row-actions-menu-items/sandbox/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "material-react-table-example-minimal",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite --port 3001",
+    "build": "vite build",
+    "serve": "vite preview",
+    "start": "vite"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.10.5",
+    "@emotion/styled": "^11.10.5",
+    "@mui/icons-material": "^5.11.0",
+    "@mui/material": "^5.11.4",
+    "material-react-table": "latest",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.26",
+    "@types/react-dom": "^18.0.10",
+    "@vitejs/plugin-react": "^3.0.1",
+    "typescript": "^4.9.4",
+    "vite": "^4.0.4"
+  }
+}

--- a/apps/material-react-table-docs/examples/row-actions-menu-items/sandbox/src/JS.js
+++ b/apps/material-react-table-docs/examples/row-actions-menu-items/sandbox/src/JS.js
@@ -1,0 +1,52 @@
+import React, { useMemo } from 'react';
+import MaterialReactTable from 'material-react-table';
+import { data } from './makeData';
+import { MenuItem } from '@mui/material';
+
+export const Example = () => {
+  const columns = useMemo(
+    //column definitions...
+    () => [
+      {
+        accessorKey: 'firstName',
+        header: 'First Name',
+      },
+      {
+        accessorKey: 'lastName',
+        header: 'Last Name',
+      },
+      {
+        accessorKey: 'address',
+        header: 'Address',
+      },
+      {
+        accessorKey: 'city',
+        header: 'City',
+      },
+      {
+        accessorKey: 'state',
+        header: 'State',
+      },
+    ],
+    [],
+    //end
+  );
+
+  return (
+    <MaterialReactTable
+      columns={columns}
+      data={data}
+      enableRowActions
+      renderRowActionMenuItems={({ row }) => [
+        <MenuItem key="edit" onClick={() => console.info('Edit')}>
+          Edit
+        </MenuItem>,
+        <MenuItem key="delete" onClick={() => console.info('Delete')}>
+          Delete
+        </MenuItem>,
+      ]}
+    />
+  );
+};
+
+export default Example;

--- a/apps/material-react-table-docs/examples/row-actions-menu-items/sandbox/src/TS.tsx
+++ b/apps/material-react-table-docs/examples/row-actions-menu-items/sandbox/src/TS.tsx
@@ -1,0 +1,52 @@
+import React, { useMemo } from 'react';
+import MaterialReactTable, { type MRT_ColumnDef } from 'material-react-table';
+import { data, type Person } from './makeData';
+import { MenuItem } from '@mui/material';
+
+export const Example = () => {
+  const columns = useMemo<MRT_ColumnDef<Person>[]>(
+    //column definitions...
+    () => [
+      {
+        accessorKey: 'firstName',
+        header: 'First Name',
+      },
+      {
+        accessorKey: 'lastName',
+        header: 'Last Name',
+      },
+      {
+        accessorKey: 'address',
+        header: 'Address',
+      },
+      {
+        accessorKey: 'city',
+        header: 'City',
+      },
+      {
+        accessorKey: 'state',
+        header: 'State',
+      },
+    ],
+    [],
+    //end
+  );
+
+  return (
+    <MaterialReactTable
+      columns={columns}
+      data={data}
+      enableRowActions
+      renderRowActionMenuItems={({ row }) => [
+        <MenuItem key="edit" onClick={() => console.info('Edit')}>
+          Edit
+        </MenuItem>,
+        <MenuItem key="delete" onClick={() => console.info('Delete')}>
+          Delete
+        </MenuItem>,
+      ]}
+    />
+  );
+};
+
+export default Example;

--- a/apps/material-react-table-docs/examples/row-actions-menu-items/sandbox/src/main.tsx
+++ b/apps/material-react-table-docs/examples/row-actions-menu-items/sandbox/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import Example from './TS';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <Example />
+  </React.StrictMode>,
+);

--- a/apps/material-react-table-docs/examples/row-actions-menu-items/sandbox/src/makeData.ts
+++ b/apps/material-react-table-docs/examples/row-actions-menu-items/sandbox/src/makeData.ts
@@ -1,0 +1,45 @@
+export type Person = {
+  firstName: string;
+  lastName: string;
+  address: string;
+  city: string;
+  state: string;
+};
+
+export const data = [
+  {
+    firstName: 'Dylan',
+    lastName: 'Murray',
+    address: '261 Erdman Ford',
+    city: 'East Daphne',
+    state: 'Kentucky',
+  },
+  {
+    firstName: 'Raquel',
+    lastName: 'Kohler',
+    address: '769 Dominic Grove',
+    city: 'Columbus',
+    state: 'Ohio',
+  },
+  {
+    firstName: 'Ervin',
+    lastName: 'Reinger',
+    address: '566 Brakus Inlet',
+    city: 'South Linda',
+    state: 'West Virginia',
+  },
+  {
+    firstName: 'Brittany',
+    lastName: 'McCullough',
+    address: '722 Emie Stream',
+    city: 'Lincoln',
+    state: 'Nebraska',
+  },
+  {
+    firstName: 'Branson',
+    lastName: 'Frami',
+    address: '32188 Larkin Turnpike',
+    city: 'Charleston',
+    state: 'South Carolina',
+  },
+];

--- a/apps/material-react-table-docs/examples/row-actions-menu-items/sandbox/src/vite.env.d.ts
+++ b/apps/material-react-table-docs/examples/row-actions-menu-items/sandbox/src/vite.env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/material-react-table-docs/examples/row-actions-menu-items/sandbox/tsconfig.json
+++ b/apps/material-react-table-docs/examples/row-actions-menu-items/sandbox/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ESNext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ]
+}

--- a/apps/material-react-table-docs/examples/row-actions-menu-items/sandbox/tsconfig.node.json
+++ b/apps/material-react-table-docs/examples/row-actions-menu-items/sandbox/tsconfig.node.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node"
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apps/material-react-table-docs/examples/row-actions-menu-items/sandbox/vite.config.js
+++ b/apps/material-react-table-docs/examples/row-actions-menu-items/sandbox/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+});

--- a/apps/material-react-table-docs/pages/docs/guides/row-actions.mdx
+++ b/apps/material-react-table-docs/pages/docs/guides/row-actions.mdx
@@ -1,5 +1,7 @@
 import Head from 'next/head';
 import RootPropTable from '../../../components/prop-tables/RootPropTable';
+import MenuItemsExample from '../../../examples/row-actions-menu-items';
+import ButtonsExample from '../../../examples/row-actions-buttons';
 
 <Head>
   <title>Row Actions Feature Guide - Material React Table Docs</title>
@@ -43,12 +45,17 @@ If you want to embed all of your row actions into a single menu, then you can us
 <MaterialReactTable
   enableRowActions
   renderRowActionMenuItems={({ row }) => [
-      <MenuItem onClick={() => console.info('Edit')}>Edit</MenuItem>,
-      <MenuItem onClick={() => console.info('Delete')}>Delete</MenuItem>
-    ]
-  )}
+    <MenuItem key="edit" onClick={() => console.info('Edit')}>
+      Edit
+    </MenuItem>,
+    <MenuItem key="delete" onClick={() => console.info('Delete')}>
+      Delete
+    </MenuItem>,
+  ]}
 />
 ```
+
+<MenuItemsExample />
 
 #### Add Row Action Buttons
 
@@ -69,6 +76,8 @@ If you want to add row action buttons, then you can use the `renderRowActions` p
   )}
 />
 ```
+
+<ButtonsExample />
 
 ### Customize Row Actions Column
 


### PR DESCRIPTION
Hey !

I noticed that there weren't any examples for row actions and I thought it would be nice to see the difference between the row action menu items vs buttons. There was also an extra `)` in the example code that I fixed !

Let me know if these examples I've created could be improved 🙂

