### PR TITLE
fix: missing memo dependency for render row actions prop

### DIFF
--- a/packages/material-react-table/src/table/MRT_TableRoot.tsx
+++ b/packages/material-react-table/src/table/MRT_TableRoot.tsx
@@ -218,6 +218,7 @@ export const MRT_TableRoot: any = <TData extends Record<string, any> = {}>(
       props.localization,
       props.positionActionsColumn,
       props.renderDetailPanel,
+      props.renderRowActions,
       props.state?.columnOrder,
       props.state?.grouping,
     ],


### PR DESCRIPTION
Fixes https://github.com/KevinVandy/material-react-table/issues/462