### PR TITLE
Remove additional <li> item from filter list

### DIFF
--- a/packages/material-react-table/src/inputs/MRT_FilterTextField.tsx
+++ b/packages/material-react-table/src/inputs/MRT_FilterTextField.tsx
@@ -344,11 +344,6 @@ export const MRT_FilterTextField = ({
             : (textFieldProps?.sx as any)),
         })}
       >
-        {(isSelectFilter || isMultiSelectFilter) && (
-          <MenuItem divider disabled hidden value="">
-            <Box sx={{ opacity: 0.5 }}>{filterPlaceholder}</Box>
-          </MenuItem>
-        )}
         {textFieldProps.children ??
           columnDef?.filterSelectOptions?.map(
             (option: string | { text: string; value: string }) => {


### PR DESCRIPTION
Hello and thank you for this amazing table library. :wave: 

This PR removes the `<li>` from the list of filtering options. Not sure if you this is something intended from your side, but since we already have the *Filter by* in the input, we probably can get rid of adding it to the list of options.

![image](https://user-images.githubusercontent.com/31070771/234334891-6f97efe0-d794-438f-bf09-dec6d1ec6586.png)
