### PR TITLE
Clicking "Filter by" will open sub menu when column filter is open

### DIFF
--- a/packages/material-react-table/src/menus/MRT_ColumnActionMenu.tsx
+++ b/packages/material-react-table/src/menus/MRT_ColumnActionMenu.tsx
@@ -229,10 +229,9 @@ export const MRT_ColumnActionMenu = ({
             </Box>
           </MenuItem>,
           <MenuItem
-            disabled={showColumnFilters && !enableColumnFilterModes}
             divider={enableGrouping || enableHiding}
             key={1}
-            onClick={handleFilterByColumn}
+            onClick={getState().showColumnFilters ? handleOpenFilterModeMenu : handleFilterByColumn}
             sx={commonMenuItemStyles}
           >
             <Box sx={commonListItemStyles}>

--- a/packages/material-react-table/src/menus/MRT_ColumnActionMenu.tsx
+++ b/packages/material-react-table/src/menus/MRT_ColumnActionMenu.tsx
@@ -229,6 +229,7 @@ export const MRT_ColumnActionMenu = ({
             </Box>
           </MenuItem>,
           <MenuItem
+            disabled={showColumnFilters && !enableColumnFilterModes}
             divider={enableGrouping || enableHiding}
             key={1}
             onClick={getState().showColumnFilters ? handleOpenFilterModeMenu : handleFilterByColumn}


### PR DESCRIPTION
If column filter is closed and you click "Filter by" it opens the column filter, but if column filter is already open and you click "filter by" it opens the sub menu.

Example: https://streamable.com/l3eewm