### PR TITLE
docs: update info related to alert toolbar 

### DIFF
--- a/apps/material-react-table-docs/pages/docs/guides/customize-toolbars.mdx
+++ b/apps/material-react-table-docs/pages/docs/guides/customize-toolbars.mdx
@@ -135,6 +135,7 @@ In all of these `render...` props, you get access to the underlying `table` inst
 ### Position Toolbar Areas
 
 The `positionToolbarAlertBanner`, `positionGlobalFilter`, `positionPagination`, and `positionToolbarDropZone` props allow you to swap the default position of certain areas of the toolbars. Experiment moving them around until you find a layout that works for you.
+You can set the property of to toolbars, `positionToolbarAlertBanner` and `positionToolbarDropZone` to `none` if you need completely hide it.
 
 ```tsx
 <MaterialReactTable
@@ -143,7 +144,7 @@ The `positionToolbarAlertBanner`, `positionGlobalFilter`, `positionPagination`, 
   //if rendering top toolbar buttons, sometimes you want alerts to be at the bottom
   positionToolbarAlertBanner="bottom"
   positionGlobalFilter="left" //move the search box to the left of the top toolbar
-  positionPagination="top"
+  positionPagination="none" //Hide the pagination toolbar
   renderTopToolbarCustomActions={() => <Box>...</Box>}
 />
 ```
@@ -175,9 +176,11 @@ The progress bars that display in both the top and bottom toolbars become visibl
 
 ### Customize Toolbar Alert Banner
 
-The toolbar alert banner is an internal component used to display alerts to the user. By default, it will automatically show messages around the number of selected rows or grouping state.
+The toolbar alert banner is an internal component used to display alerts to the user. By default, it will automatically show messages around the number of row(s) selected or grouping state.
 
-However, you can repurpose this alert banner to show your own custom messages too. You can force the alert banner to show by setting the `showAlertBanner` state option to `true`. You can then customize the messages and other stylings using the `muiToolbarAlertBannerProps` to create your custom message. You probably saw this in the [Remote Data](/docs/examples/remote) or [React Query](/docs/examples/react-query) examples.
+However, you can repurpose this alert banner to show your own custom messages too. You can force the alert banner to show by setting the `showAlertBanner` state option to `true`.
+By setting the `showAlertBanner` to `false`, you can hide the alert banner completely, which can be useful in overriding the default state when there are row(s) selected or grouped.
+You can then customize the messages and other stylings using the `muiToolbarAlertBannerProps` to create your custom message. You probably saw this in the [Remote Data](/docs/examples/remote) or [React Query](/docs/examples/react-query) examples.
 
 ```tsx
 <MaterialReactTable


### PR DESCRIPTION
The properties have already been well defined, but the problem is knowing that the 'x of n row(s) selected' and grouping message is managed by the AlertToolbar Component. When i was searching the docs' I was trying stuff like '4 of 5 row(s) selected' & 'row(s) selected' and didn't hit any results. 

Seems like a couple of folks on discord did this too 
<img width="413" alt="image" src="https://github.com/KevinVandy/material-react-table/assets/3579142/2725d47f-8e05-433e-bd19-aca7f75aa960">
