### PR TITLE
Range slider, array of arrays from getFacetedMinMaxValues()

### DIFF
--- a/packages/material-react-table/src/inputs/MRT_FilterRangeSlider.tsx
+++ b/packages/material-react-table/src/inputs/MRT_FilterRangeSlider.tsx
@@ -45,10 +45,21 @@ export const MRT_FilterRangeSlider = ({ header, table }: Props) => {
     ...mcTableHeadCellFilterTextFieldProps,
   } as SliderProps;
 
-  const [min, max] =
+  let [min, max] =
     sliderProps.min !== undefined && sliderProps.max !== undefined
       ? [sliderProps.min, sliderProps.max]
       : column.getFacetedMinMaxValues() ?? [0, 0];
+
+  // column.getFacetedMinMaxValues() seems to return an array of arrays for the min value
+  // under some conditions, so check for that and take the first array value if that happens.
+  // To be a bit defensive, implement the same check for max, just in case.
+  if (Array.isArray(min)) {
+    min = min[0]
+  }
+  if (Array.isArray(max)) {
+    max = max[0]
+  }
+
   const [filterValues, setFilterValues] = useState([min, max]);
   const columnFilterValue = column.getFilterValue();
 


### PR DESCRIPTION
This commit implements a simple array check for the values returned by getFacetedMinMaxValues(). The bug was encountered while using range-slider for column that had two rows, and the first row had a smaller value in the column which was controlled by the range slider. In this configuration, the min value of the result from getFacetedMinMaxValues was an array, when a number was expected. Pretty much any other configuration seemed to work, but since this pretty hard to know for sure, the same check is implemented for the max value too.