### PR TITLE
Selected pinned column transparent background on hover

### DIFF
--- a/packages/material-react-table/src/body/MRT_TableBodyRow.tsx
+++ b/packages/material-react-table/src/body/MRT_TableBodyRow.tsx
@@ -1,6 +1,6 @@
 import { type DragEvent, memo, useRef } from 'react';
 import TableRow from '@mui/material/TableRow';
-import { type Theme, alpha, darken, lighten } from '@mui/material/styles';
+import { type Theme, darken, lighten } from '@mui/material/styles';
 import { Memo_MRT_TableBodyCell, MRT_TableBodyCell } from './MRT_TableBodyCell';
 import { MRT_TableDetailPanel } from './MRT_TableDetailPanel';
 import { type VirtualItem, type Virtualizer } from '@tanstack/react-virtual';
@@ -85,7 +85,7 @@ export const MRT_TableBodyRow = ({
             backgroundColor:
               tableRowProps?.hover !== false
                 ? row.getIsSelected()
-                  ? `${alpha(theme.palette.primary.main, 0.2)}`
+                  ? `${darken(theme.palette.primary.main, 0.4)}`
                   : theme.palette.mode === 'dark'
                   ? `${lighten(theme.palette.background.default, 0.12)}`
                   : `${darken(theme.palette.background.default, 0.05)}`


### PR DESCRIPTION
This commit changes the background color of the hovered selected row using the darken utility function provided by MUI instead of the alpha utility function to get a slightly darkened background without having the transparent side effect. The change relates to an issue where when we have a pinned column and we select a row and we scroll left or right the background of the pinned cell is almost transparent and the data of the cell under the pinned column is overlapping with the pinned colum's data making it hard to read. It also allows clicking on the "mrt-row-select" cell under the pinned column if the "mrt-row-select" column is directly under the pinned column it is interactive through the pinned column and can be clicked.

The change is to use the darken utility function provided by MUI instead of alpha to get a bit darkened color of the primary theme color just like the alpha utility function but without having the background be transparent.