### PR TITLE
There is a wrong column order when using columnVirtualization and pinned columns

### DIFF
--- a/packages/material-react-table/src/body/MRT_TableBodyRow.tsx
+++ b/packages/material-react-table/src/body/MRT_TableBodyRow.tsx
@@ -103,7 +103,10 @@ export const MRT_TableBodyRow = ({
           ...tableRowProps?.style,
         }}
       >
-        {(virtualColumns ?? row.getVisibleCells()).map((cellOrVirtualCell, idx) => {
+        {(virtualPaddingLeft && table.getLeftLeafColumns().length === 0) ? (
+            <td style={{ display: 'flex', width: virtualPaddingRight }} />
+        ) : null}
+        {(virtualColumns ?? row.getVisibleCells()).map((cellOrVirtualCell) => {
           const cell = columnVirtualizer
             ? row.getVisibleCells()[(cellOrVirtualCell as VirtualItem).index]
             : (cellOrVirtualCell as MRT_Cell);
@@ -130,16 +133,21 @@ export const MRT_TableBodyRow = ({
             <MRT_TableBodyCell key={cell.id} {...props} />
           );
 
-          if (idx === (table.getLeftLeafColumns().length - 1) && virtualColumns) {
+          if (virtualPaddingLeft && (cellOrVirtualCell as VirtualItem).index === (table.getLeftLeafColumns().length - 1)) {
             return [
               renderedCell,
               <th key="vp_left" style={{ display: 'flex', width: virtualPaddingLeft }} />,
+            ]
+          } else if (virtualPaddingRight && (cellOrVirtualCell as VirtualItem).index === (table.getVisibleLeafColumns().length - table.getRightLeafColumns().length)) {
+            return [
+              <th key="vp_right"  style={{ display: 'flex', width: virtualPaddingRight }} />,
+              renderedCell
             ]
           } else {
             return renderedCell;
           }
         })}
-        {virtualPaddingRight ? (
+        {(virtualPaddingRight && table.getRightLeafColumns().length === 0) ? (
           <td style={{ display: 'flex', width: virtualPaddingRight }} />
         ) : null}
       </TableRow>

--- a/packages/material-react-table/src/body/MRT_TableBodyRow.tsx
+++ b/packages/material-react-table/src/body/MRT_TableBodyRow.tsx
@@ -5,7 +5,6 @@ import { Memo_MRT_TableBodyCell, MRT_TableBodyCell } from './MRT_TableBodyCell';
 import { MRT_TableDetailPanel } from './MRT_TableDetailPanel';
 import { type VirtualItem, type Virtualizer } from '@tanstack/react-virtual';
 import { type MRT_Cell, type MRT_Row, type MRT_TableInstance } from '../types';
-import {MRT_TableHeadCell} from "../head/MRT_TableHeadCell";
 
 interface Props {
   columnVirtualizer?: Virtualizer<HTMLDivElement, HTMLTableCellElement>;

--- a/packages/material-react-table/src/body/MRT_TableBodyRow.tsx
+++ b/packages/material-react-table/src/body/MRT_TableBodyRow.tsx
@@ -5,6 +5,7 @@ import { Memo_MRT_TableBodyCell, MRT_TableBodyCell } from './MRT_TableBodyCell';
 import { MRT_TableDetailPanel } from './MRT_TableDetailPanel';
 import { type VirtualItem, type Virtualizer } from '@tanstack/react-virtual';
 import { type MRT_Cell, type MRT_Row, type MRT_TableInstance } from '../types';
+import {MRT_TableHeadCell} from "../head/MRT_TableHeadCell";
 
 interface Props {
   columnVirtualizer?: Virtualizer<HTMLDivElement, HTMLTableCellElement>;
@@ -102,13 +103,11 @@ export const MRT_TableBodyRow = ({
           ...tableRowProps?.style,
         }}
       >
-        {virtualPaddingLeft ? (
-          <td style={{ display: 'flex', width: virtualPaddingLeft }} />
-        ) : null}
-        {(virtualColumns ?? row.getVisibleCells()).map((cellOrVirtualCell) => {
+        {(virtualColumns ?? row.getVisibleCells()).map((cellOrVirtualCell, idx) => {
           const cell = columnVirtualizer
             ? row.getVisibleCells()[(cellOrVirtualCell as VirtualItem).index]
             : (cellOrVirtualCell as MRT_Cell);
+
           const props = {
             cell,
             measureElement: columnVirtualizer?.measureElement,
@@ -120,7 +119,7 @@ export const MRT_TableBodyRow = ({
               ? (cellOrVirtualCell as VirtualItem)
               : undefined,
           };
-          return memoMode === 'cells' &&
+          const renderedCell = memoMode === 'cells' &&
             cell.column.columnDef.columnDefType === 'data' &&
             !draggingColumn &&
             !draggingRow &&
@@ -130,6 +129,15 @@ export const MRT_TableBodyRow = ({
           ) : (
             <MRT_TableBodyCell key={cell.id} {...props} />
           );
+
+          if (idx === (table.getLeftLeafColumns().length - 1) && virtualColumns) {
+            return [
+              renderedCell,
+              <th key="vp_left" style={{ display: 'flex', width: virtualPaddingLeft }} />,
+            ]
+          } else {
+            return renderedCell;
+          }
         })}
         {virtualPaddingRight ? (
           <td style={{ display: 'flex', width: virtualPaddingRight }} />

--- a/packages/material-react-table/src/head/MRT_TableHeadRow.tsx
+++ b/packages/material-react-table/src/head/MRT_TableHeadRow.tsx
@@ -45,23 +45,31 @@ export const MRT_TableHeadRow = ({
           : (tableRowProps?.sx as any)),
       })}
     >
-      {(virtualColumns ?? headerGroup.headers).map((headerOrVirtualHeader, idx) => {
+      {(virtualPaddingLeft && table.getLeftLeafColumns().length === 0) ? (
+          <td style={{ display: 'flex', width: virtualPaddingRight }} />
+      ) : null}
+      {(virtualColumns ?? headerGroup.headers).map((headerOrVirtualHeader) => {
         const header = virtualColumns
           ? headerGroup.headers[headerOrVirtualHeader.index]
           : (headerOrVirtualHeader as MRT_Header);
 
         const renderedCell = <MRT_TableHeadCell header={header} key={header.id} table={table} />;
-        if (idx === (table.getLeftLeafColumns().length - 1) && virtualColumns) {
+        if (virtualPaddingLeft && headerOrVirtualHeader.index === (table.getLeftLeafColumns().length - 1)) {
             return [
                 renderedCell,
                 <th key="vp_left"  style={{ display: 'flex', width: virtualPaddingLeft }} />,
+            ]
+        } else if (virtualPaddingRight && headerOrVirtualHeader.index === (table.getVisibleLeafColumns().length - table.getRightLeafColumns().length)) {
+            return [
+                <th key="vp_right"  style={{ display: 'flex', width: virtualPaddingRight }} />,
+                renderedCell
             ]
         } else {
             return renderedCell;
         }
       })}
-      {virtualPaddingRight ? (
-        <th style={{ display: 'flex', width: virtualPaddingRight }} />
+      {(virtualPaddingRight && table.getRightLeafColumns().length === 0) ? (
+          <td style={{ display: 'flex', width: virtualPaddingRight }} />
       ) : null}
     </TableRow>
   );

--- a/packages/material-react-table/src/head/MRT_TableHeadRow.tsx
+++ b/packages/material-react-table/src/head/MRT_TableHeadRow.tsx
@@ -45,17 +45,20 @@ export const MRT_TableHeadRow = ({
           : (tableRowProps?.sx as any)),
       })}
     >
-      {virtualPaddingLeft ? (
-        <th style={{ display: 'flex', width: virtualPaddingLeft }} />
-      ) : null}
-      {(virtualColumns ?? headerGroup.headers).map((headerOrVirtualHeader) => {
+      {(virtualColumns ?? headerGroup.headers).map((headerOrVirtualHeader, idx) => {
         const header = virtualColumns
           ? headerGroup.headers[headerOrVirtualHeader.index]
           : (headerOrVirtualHeader as MRT_Header);
 
-        return (
-          <MRT_TableHeadCell header={header} key={header.id} table={table} />
-        );
+        const renderedCell = <MRT_TableHeadCell header={header} key={header.id} table={table} />;
+        if (idx === (table.getLeftLeafColumns().length - 1) && virtualColumns) {
+            return [
+                renderedCell,
+                <th key="vp_left"  style={{ display: 'flex', width: virtualPaddingLeft }} />,
+            ]
+        } else {
+            return renderedCell;
+        }
       })}
       {virtualPaddingRight ? (
         <th style={{ display: 'flex', width: virtualPaddingRight }} />

--- a/packages/material-react-table/src/table/MRT_Table.tsx
+++ b/packages/material-react-table/src/table/MRT_Table.tsx
@@ -129,7 +129,8 @@ export const MRT_Table = ({ table }: Props) => {
   let virtualPaddingRight: number | undefined;
 
   if (columnVirtualizer && virtualColumns?.length) {
-    virtualPaddingLeft = virtualColumns[leftPinnedIndexes.length]?.start ?? 0;
+    virtualPaddingLeft = Math.max(0, (virtualColumns[leftPinnedIndexes.length]?.start ?? 0) -
+        (virtualColumns[leftPinnedIndexes.length - 1]?.end ?? 0));
     virtualPaddingRight =
       columnVirtualizer.getTotalSize() -
       (virtualColumns[virtualColumns.length - 1 - rightPinnedIndexes.length]

--- a/packages/material-react-table/src/table/MRT_Table.tsx
+++ b/packages/material-react-table/src/table/MRT_Table.tsx
@@ -130,11 +130,11 @@ export const MRT_Table = ({ table }: Props) => {
 
   if (columnVirtualizer && virtualColumns?.length) {
     virtualPaddingLeft = Math.max(0, (virtualColumns[leftPinnedIndexes.length]?.start ?? 0) -
-        (virtualColumns[leftPinnedIndexes.length - 1]?.end ?? 0));
-    virtualPaddingRight =
-      columnVirtualizer.getTotalSize() -
-      (virtualColumns[virtualColumns.length - 1 - rightPinnedIndexes.length]
-        ?.end ?? 0);
+        (leftPinnedIndexes.length === 0 ? 0 : (virtualColumns[leftPinnedIndexes.length - 1]?.end ?? 0)));
+    virtualPaddingRight = Math.max(0,
+      (columnVirtualizer.getTotalSize() - (virtualColumns[virtualColumns.length - 1 - rightPinnedIndexes.length]?.end ?? 0)) -
+        (rightPinnedIndexes.length === 0 ? 0 :
+            (columnVirtualizer.getTotalSize() - (virtualColumns[virtualColumns.length - rightPinnedIndexes.length]?.start ?? 0))));
   }
 
   const props = {


### PR DESCRIPTION
The problem is that the sticky columns left and right are pulled to the middle and als at the end of the scroll the extra padding remains in the outside of the pinned columns.

Proposed fix is to have the padding column be on the inside of the pinned columns.