### PR TITLE
Allow new lines to be entered when editing textareas

### DIFF
--- a/packages/material-react-table/src/inputs/MRT_EditCellTextField.tsx
+++ b/packages/material-react-table/src/inputs/MRT_EditCellTextField.tsx
@@ -82,7 +82,7 @@ export const MRT_EditCellTextField = <TData extends Record<string, any>>({
 
   const handleEnterKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
     textFieldProps.onKeyDown?.(event);
-    if (event.key === 'Enter') {
+    if (event.key === 'Enter' && !event.shiftKey) {
       editInputRefs.current[column.id]?.blur();
     }
   };


### PR DESCRIPTION
Previously, new lines could not be entered when editing textareas (i.e setting `multiline: true` on the `muiEditTextFieldProps` prop). This change allows the user to enter new lines when editing textareas.