### PR TITLE
Fix the image to feel it's at scale 1:1

### DIFF
--- a/apps/material-react-table-docs/pages/blog/the-best-react-data-grid-table-libraries-with-material-design-in-2023.mdx
+++ b/apps/material-react-table-docs/pages/blog/the-best-react-data-grid-table-libraries-with-material-design-in-2023.mdx
@@ -64,13 +64,13 @@ Here are the top three data grid/table libraries that I recommend for Material U
   height={800}
   layout="responsive"
   src="/blog-imgs/best-table-libs/mui-x-example.png"
-  style={{ borderRadius: '8px', margin: '2rem auto', maxWidth: '1000px' }}
+  style={{ borderRadius: '8px', margin: '2rem auto', maxWidth: '850px' }}
   width={800}
 />
 
 The [MUI X DataGrid](https://mui.com/x/react-data-grid/) package comes directly from MUI, so you are guaranteed to at least get a solid feature-rich table that integrates perfectly with the rest of your Material UI components. It is very well maintained, and you can get pretty good support from the MUI team if you run into any issues.
 
-It has just about every table feature you might need, but one caveat is that some of the features are only available in either the paid Pro or Premium versions. There is a free MIT version, of course, but be aware of the vender lock-in you might get yourself into if you choose to use this library. If you are building a commercial product, paying for a library like this might be worth it, but take a look at the other options first to see if they will work for you.
+It has just about every table feature you might need, but one caveat is that some of the features are only available in either the paid Pro or Premium versions. There is a free MIT version, of course, but be aware of the vendor lock-in you might get yourself into if you choose to use this library. If you are building a commercial product, paying for a library like this might be worth it, but take a look at the other options first to see if they will work for you.
 
 <EthicalAd id="blog" />
 


### PR DESCRIPTION
On https://www.material-react-table.com/blog/the-best-react-data-grid-table-libraries-with-material-design-in-2023#1.-mui-x-datagrid-(mit-or-pro-premium), the screenshots make it feels like the component is different than in it default look & feel.

This PR aim to restore the 1:1 scale.

cc @KevinVandy