### PR TITLE
fix: cast renderCellValue to string to highlight value

### DIFF
--- a/packages/material-react-table/src/body/MRT_TableBodyCellValue.tsx
+++ b/packages/material-react-table/src/body/MRT_TableBodyCellValue.tsx
@@ -56,7 +56,7 @@ export const MRT_TableBodyCellValue = <TData extends MRT_RowData>({
   if (
     enableFilterMatchHighlighting &&
     columnDef.enableFilterMatchHighlighting !== false &&
-    renderedCellValue &&
+    String(renderedCellValue) &&
     allowedTypes.includes(typeof renderedCellValue) &&
     ((filterValue &&
       allowedTypes.includes(typeof filterValue) &&


### PR DESCRIPTION
This pr is related to the [#761 issue]( https://github.com/KevinVandy/material-react-table/issues/761)