### PR TITLE
fix MRT_TableHeadRow props

### DIFF
--- a/packages/material-react-table/src/head/MRT_TableHeadRow.tsx
+++ b/packages/material-react-table/src/head/MRT_TableHeadRow.tsx
@@ -36,7 +36,7 @@ export const MRT_TableHeadRow = <TData extends MRT_RowData>({
       headerGroup,
       table,
     }),
-    rest,
+    ...rest,
   };
 
   return (


### PR DESCRIPTION
The props in `rest` are not spreaded, leading to a property called `rest=[object Object]` appearing on the resulting `<tr>` element instead.

This PR fixes the bug, simply by spreading `rest`.