### PR TITLE
fix typo in docs - virual to virtual

### DIFF
--- a/apps/material-react-table-docs/pages/docs/examples/column-virtualization.mdx
+++ b/apps/material-react-table-docs/pages/docs/examples/column-virtualization.mdx
@@ -19,7 +19,7 @@ import Examples from '../../../example-groups/VirtualizedExamples';
 
 ## Column Virtualization Example
 
-Material React Table has a built-in column virtualization feature (via [`@tanstack/react-virual`](https://tanstack.com/virtual/v3)) that allows you to render a large number of columns without major performance issues that you would normally see with a large number of DOM elements.
+Material React Table has a built-in column virtualization feature (via [`@tanstack/react-virtual`](https://tanstack.com/virtual/v3)) that allows you to render a large number of columns without major performance issues that you would normally see with a large number of DOM elements.
 
 Try out the performance of the table below with **500 columns**! Filtering, Search, and Sorting also maintain usable performance.
 

--- a/apps/material-react-table-docs/pages/docs/examples/row-virtualization.mdx
+++ b/apps/material-react-table-docs/pages/docs/examples/row-virtualization.mdx
@@ -19,7 +19,7 @@ import Examples from '../../../example-groups/VirtualizedExamples';
 
 ## Row Virtualization Example
 
-Material React Table has a built-in row virtualization feature (via [`@tanstack/react-virual`](https://tanstack.com/virtual/v3)) that allows you to render a large number of rows without major performance issues that you would normally see with a large number of DOM elements.
+Material React Table has a built-in row virtualization feature (via [`@tanstack/react-virtual`](https://tanstack.com/virtual/v3)) that allows you to render a large number of rows without major performance issues that you would normally see with a large number of DOM elements.
 
 Try out the performance of the table below with **10,000 rows**! Filtering, Search, and Sorting also maintain usable performance.
 

--- a/apps/material-react-table-docs/pages/docs/examples/virtualized.mdx
+++ b/apps/material-react-table-docs/pages/docs/examples/virtualized.mdx
@@ -19,7 +19,7 @@ import Examples from '../../../example-groups/VirtualizedExamples';
 
 ## Virtualized Example
 
-Material React Table has a built-in virtualization features (via [`@tanstack/react-virual`](https://tanstack.com/virtual/v3)) that allows you to render a large number of rows or columns without major performance issues that you would normally see with a large number of DOM elements.
+Material React Table has a built-in virtualization features (via [`@tanstack/react-virtual`](https://tanstack.com/virtual/v3)) that allows you to render a large number of rows or columns without major performance issues that you would normally see with a large number of DOM elements.
 
 Try out the performance of the table below with **10,000 rows** and over a dozen columns! Filtering, Search, and Sorting also maintain usable performance.
 


### PR DESCRIPTION
just fixed some typo like this. Links are fine but only I saw is a typo. 

```
// BEFORE
virual

// AFTER
virtual
```
