### PR TITLE
fix: wrong order when columns prop changes

### DIFF
--- a/packages/material-react-table/src/hooks/useMRT_TableInstance.ts
+++ b/packages/material-react-table/src/hooks/useMRT_TableInstance.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   getCoreRowModel,
   getExpandedRowModel,
@@ -84,6 +84,12 @@ export const useMRT_TableInstance: <TData extends MRT_RowData>(
   const [columnOrder, setColumnOrder] = useState<MRT_ColumnOrderState>(
     initialState.columnOrder ?? [],
   );
+  useEffect(() => {
+    const initState = tableOptions.initialState ?? {};
+    setColumnOrder(
+      initState.columnOrder ?? getDefaultColumnOrderIds(tableOptions),
+    );
+  }, [tableOptions.columns]);
   const [density, setDensity] = useState<MRT_DensityState>(
     initialState?.density ?? 'comfortable',
   );


### PR DESCRIPTION
After modifying the columns, they appear at the end of the table instead of being displayed in the order provided. 

```
export const CustomRowActionButtonsLastColumn = () => {
  const [columns, setColumns] = useState([
    { accessorKey: 'key2', header: 'header2' },
  ]);
  return (
    <MaterialReactTable
      columns={columns}
      data={[{ key2: 'value2' }]}
      enableRowActions
      positionActionsColumn="last"
      renderRowActions={() => (
        <Button
          onClick={() => {
            setColumns([
              { accessorKey: 'key1', header: 'header1' },
              { accessorKey: 'key2', header: 'header2' },
              { accessorKey: 'key3', header: 'header3' },
            ]);
          }}
        >
          action
        </Button>
      )}
    />
  );
};
```
<img width="785" alt="image" src="https://github.com/KevinVandy/material-react-table/assets/32033682/532b3cb1-ecb7-47d0-8151-d6918c5cb22c">
