### PR TITLE
Fix default SelectProps overwritten if defined in muiFilterTextFieldProps

### DIFF
--- a/packages/material-react-table/src/inputs/MRT_FilterTextField.tsx
+++ b/packages/material-react-table/src/inputs/MRT_FilterTextField.tsx
@@ -402,9 +402,9 @@ export const MRT_FilterTextField = <TData extends MRT_RowData>({
         />
       ) : (
         <TextField
-          onChange={handleTextFieldChange}
           select={isSelectFilter || isMultiSelectFilter}
           {...commonTextFieldProps}
+          onChange={handleTextFieldChange}
           SelectProps={{
             displayEmpty: true,
             multiple: isMultiSelectFilter,

--- a/packages/material-react-table/src/inputs/MRT_FilterTextField.tsx
+++ b/packages/material-react-table/src/inputs/MRT_FilterTextField.tsx
@@ -402,6 +402,9 @@ export const MRT_FilterTextField = <TData extends MRT_RowData>({
         />
       ) : (
         <TextField
+          onChange={handleTextFieldChange}
+          select={isSelectFilter || isMultiSelectFilter}
+          {...commonTextFieldProps}
           SelectProps={{
             displayEmpty: true,
             multiple: isMultiSelectFilter,
@@ -425,10 +428,8 @@ export const MRT_FilterTextField = <TData extends MRT_RowData>({
                     </Box>
                   )
               : undefined,
+            ...commonTextFieldProps.SelectProps
           }}
-          onChange={handleTextFieldChange}
-          select={isSelectFilter || isMultiSelectFilter}
-          {...commonTextFieldProps}
           value={filterValue ?? ''}
         >
           {(isSelectFilter || isMultiSelectFilter) && [


### PR DESCRIPTION
This PR fixes issue when you want to pass extra params to `SelectProps` it removes default options like `renderValue`, `multiple`, `displayEmpty`