### PR TITLE
Fix warning virtualIndex in MRT_TableBodyCell

### DIFF
--- a/packages/material-react-table/src/body/MRT_TableBodyRow.tsx
+++ b/packages/material-react-table/src/body/MRT_TableBodyRow.tsx
@@ -219,7 +219,7 @@ export const MRT_TableBodyRow = <TData extends MRT_RowData>({
             rowIndex,
             rowRef,
             table,
-            virtualIndex: columnVirtualizer
+            virtualColumnIndex: columnVirtualizer
               ? (cellOrVirtualCell as VirtualItem).index
               : undefined,
           };


### PR DESCRIPTION
This PR fixes issue #899 