### PR TITLE
Feat: creating row with external button

### DIFF
--- a/packages/material-react-table/src/buttons/MRT_EditActionButtons.tsx
+++ b/packages/material-react-table/src/buttons/MRT_EditActionButtons.tsx
@@ -98,15 +98,18 @@ export const MRT_EditActionButtons = <TData extends MRT_RowData>({
               <CancelIcon />
             </IconButton>
           </Tooltip>
-          <Tooltip title={localization.save}>
-            <IconButton
-              aria-label={localization.save}
-              color="info"
-              onClick={handleSubmitRow}
-            >
-              {isSaving ? <CircularProgress size={18} /> : <SaveIcon />}
-            </IconButton>
-          </Tooltip>
+          {((isCreating && onCreatingRowSave) ||
+            (isEditing && onEditingRowSave)) && (
+            <Tooltip title={localization.save}>
+              <IconButton
+                aria-label={localization.save}
+                color="info"
+                onClick={handleSubmitRow}
+              >
+                {isSaving ? <CircularProgress size={18} /> : <SaveIcon />}
+              </IconButton>
+            </Tooltip>
+          )}
         </>
       ) : (
         <>

--- a/packages/material-react-table/src/hooks/useMRT_DisplayColumns.tsx
+++ b/packages/material-react-table/src/hooks/useMRT_DisplayColumns.tsx
@@ -136,7 +136,9 @@ function makeRowActionsColumn<TData extends MRT_RowData>(
   const id: MRT_DisplayColumnIds = 'mrt-row-actions';
   if (
     order.includes(id) ||
-    (creatingRow && tableOptions.createDisplayMode === 'row')
+    (creatingRow &&
+      tableOptions.createDisplayMode === 'row' &&
+      (tableOptions.onCreatingRowSave || tableOptions.onCreatingRowCancel))
   ) {
     return {
       Cell: ({ cell, row, table }) => (

--- a/packages/material-react-table/src/hooks/useMRT_DisplayColumns.tsx
+++ b/packages/material-react-table/src/hooks/useMRT_DisplayColumns.tsx
@@ -136,9 +136,7 @@ function makeRowActionsColumn<TData extends MRT_RowData>(
   const id: MRT_DisplayColumnIds = 'mrt-row-actions';
   if (
     order.includes(id) ||
-    (creatingRow &&
-      tableOptions.createDisplayMode === 'row' &&
-      (tableOptions.onCreatingRowSave || tableOptions.onCreatingRowCancel))
+    (creatingRow && tableOptions.createDisplayMode === 'row')
   ) {
     return {
       Cell: ({ cell, row, table }) => (

--- a/packages/material-react-table/stories/features/Editing.stories.tsx
+++ b/packages/material-react-table/stories/features/Editing.stories.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
 import MenuItem from '@mui/material/MenuItem';
 import {
   type MRT_Cell,
@@ -288,7 +289,28 @@ export const EditingEnabledEditModeCell = () => {
         },
       })}
       renderTopToolbarCustomActions={({ table }) => (
-        <Button onClick={() => table.setCreatingRow(true)}>Add</Button>
+        <Stack direction="row" gap={3}>
+          <Button
+            variant="outlined"
+            onClick={() => {
+              if (table.getState().creatingRow) {
+                table.setCreatingRow(null);
+                return;
+              }
+              table.setCreatingRow(true);
+            }}
+          >
+            {!table.getState().creatingRow ? 'Add' : 'Cancel'}
+          </Button>
+
+          <Button
+            disabled={!table.getState().creatingRow}
+            variant="contained"
+            onClick={() => table.setCreatingRow(null)}
+          >
+            Save
+          </Button>
+        </Stack>
       )}
     />
   );

--- a/packages/material-react-table/stories/features/Editing.stories.tsx
+++ b/packages/material-react-table/stories/features/Editing.stories.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import Button from '@mui/material/Button';
-import Stack from '@mui/material/Stack';
 import MenuItem from '@mui/material/MenuItem';
 import {
   type MRT_Cell,
@@ -179,10 +178,67 @@ export const EditingEnabledEditModeRow = () => {
       data={tableData}
       editDisplayMode="row"
       enableEditing
+      onCreatingRowSave={() => {}}
       onEditingRowSave={handleSaveRow}
       renderTopToolbarCustomActions={({ table }) => (
         <Button onClick={() => table.setCreatingRow(true)}>Add</Button>
       )}
+    />
+  );
+};
+
+export const EditingEnabledEditModeRowCustomSave = () => {
+  const [tableData, setTableData] = useState(data);
+
+  const handleSaveRow: MRT_TableOptions<Person>['onEditingRowSave'] = ({
+    exitEditingMode,
+    row,
+    values,
+  }) => {
+    tableData[row.index] = values;
+    setTableData([...tableData]);
+    exitEditingMode();
+  };
+
+  return (
+    <MaterialReactTable
+      columns={[
+        {
+          accessorKey: 'firstName',
+          header: 'First Name',
+        },
+        {
+          accessorKey: 'lastName',
+          header: 'Last Name',
+        },
+        {
+          accessorKey: 'address',
+          header: 'Address',
+        },
+        {
+          accessorKey: 'state',
+          header: 'State',
+        },
+        {
+          accessorKey: 'phoneNumber',
+          enableEditing: false,
+          header: 'Phone Number',
+        },
+      ]}
+      createDisplayMode="row"
+      data={tableData}
+      editDisplayMode="row"
+      enableEditing
+      onEditingRowSave={handleSaveRow}
+      renderTopToolbarCustomActions={({ table }) =>
+        table.getState().creatingRow ? (
+          <Button color="success" onClick={() => {}}>
+            Save
+          </Button>
+        ) : (
+          <Button onClick={() => table.setCreatingRow(true)}>Add</Button>
+        )
+      }
     />
   );
 };
@@ -238,6 +294,7 @@ export const EditingEnabledEditModeRowVirtualized = () => {
       enableRowSelection
       enableRowVirtualization
       muiTableContainerProps={{ sx: { height: 400 } }}
+      onCreatingRowSave={() => {}}
       onEditingRowSave={handleSaveRow}
       renderTopToolbarCustomActions={({ table }) => (
         <Button onClick={() => table.setCreatingRow(true)}>Add</Button>
@@ -289,29 +346,9 @@ export const EditingEnabledEditModeCell = () => {
           handleSaveCell(cell, event.target.value);
         },
       })}
+      onCreatingRowSave={() => {}}
       renderTopToolbarCustomActions={({ table }) => (
-        <Stack direction="row" gap={3}>
-          <Button
-            variant="outlined"
-            onClick={() => {
-              if (table.getState().creatingRow) {
-                table.setCreatingRow(null);
-                return;
-              }
-              table.setCreatingRow(true);
-            }}
-          >
-            {!table.getState().creatingRow ? 'Add' : 'Cancel'}
-          </Button>
-
-          <Button
-            disabled={!table.getState().creatingRow}
-            variant="contained"
-            onClick={() => table.setCreatingRow(null)}
-          >
-            Save
-          </Button>
-        </Stack>
+        <Button onClick={() => table.setCreatingRow(true)}>Add</Button>
       )}
     />
   );
@@ -361,6 +398,7 @@ export const EditingEnabledEditModeCellWithRowActions = () => {
           handleSaveCell(cell, event.target.value);
         },
       })}
+      onCreatingRowSave={() => {}}
       renderTopToolbarCustomActions={({ table }) => (
         <Button onClick={() => table.setCreatingRow(true)}>Add</Button>
       )}


### PR DESCRIPTION
Hello @KevinVandy,

According to your code, when using ```creatingDisplayMode = 'row'```, it will automatically create ```save``` and ```cancel``` buttons in the ```action``` column.

But in my case, I want to use ```save```, ```cancel``` buttons in the table header to be able to control ```creatingRow```. Can you review and merge the code?

Example:
![image](https://github.com/KevinVandy/material-react-table/assets/56160839/bf3350e4-31a7-4377-9110-8342106ee9ed)
