### PR TITLE
Fix pagination props being invalid in docs

### DIFF
--- a/apps/material-react-table-docs/pages/docs/guides/pagination.mdx
+++ b/apps/material-react-table-docs/pages/docs/guides/pagination.mdx
@@ -104,7 +104,7 @@ const table = useMaterialReactTable({
   columns,
   data,
   muiPaginationProps: {
-    rowsPerPageOptions: ['5', '10', '20'],
+    rowsPerPageOptions: [5, 10, 20],
     showFirstButton: false,
     showLastButton: false,
   },


### PR DESCRIPTION
Should be an array of numbers, not strings. https://github.com/KevinVandy/material-react-table/blob/v2/packages/material-react-table/src/toolbar/MRT_TablePagination.tsx#L18