### PR TITLE
Fixed Show clear filter menu if emptyModes filter fns is selected

### DIFF
--- a/packages/material-react-table/src/menus/MRT_ColumnActionMenu.tsx
+++ b/packages/material-react-table/src/menus/MRT_ColumnActionMenu.tsx
@@ -206,23 +206,25 @@ export const MRT_ColumnActionMenu = <TData extends MRT_RowData>({
       : []),
     ...(enableColumnFilters && column.getCanFilter()
       ? [
-          <MenuItem
-            disabled={
-              !columnFilterValue ||
-              (Array.isArray(columnFilterValue) &&
-                !columnFilterValue.filter((value) => value).length)
-            }
-            key={3}
-            onClick={handleClearFilter}
-            sx={commonMenuItemStyles}
-          >
-            <Box sx={commonListItemStyles}>
-              <ListItemIcon>
-                <FilterListOffIcon />
-              </ListItemIcon>
-              {localization.clearFilter}
-            </Box>
-          </MenuItem>,
+          !['empty', 'notEmpty'].includes(columnDef._filterFn) && (
+            <MenuItem
+              disabled={
+                !columnFilterValue ||
+                (Array.isArray(columnFilterValue) &&
+                  !columnFilterValue.filter((value) => value).length)
+              }
+              key={3}
+              onClick={handleClearFilter}
+              sx={commonMenuItemStyles}
+            >
+              <Box sx={commonListItemStyles}>
+                <ListItemIcon>
+                  <FilterListOffIcon />
+                </ListItemIcon>
+                {localization.clearFilter}
+              </Box>
+            </MenuItem>
+          ),
           columnFilterDisplayMode === 'subheader' && (
             <MenuItem
               disabled={showColumnFilters && !enableColumnFilterModes}

--- a/packages/material-react-table/src/menus/MRT_ColumnActionMenu.tsx
+++ b/packages/material-react-table/src/menus/MRT_ColumnActionMenu.tsx
@@ -67,6 +67,7 @@ export const MRT_ColumnActionMenu = <TData extends MRT_RowData>({
       renderColumnActionsMenuItems,
     },
     refs: { filterInputRefs },
+    setColumnFilterFns,
     setColumnOrder,
     setColumnSizingInfo,
     setShowColumnFilters,
@@ -119,8 +120,14 @@ export const MRT_ColumnActionMenu = <TData extends MRT_RowData>({
   };
 
   const handleClearFilter = () => {
-    column.setFilterValue('');
+    column.setFilterValue(undefined);
     setAnchorEl(null);
+    if (['empty', 'notEmpty'].includes(columnDef._filterFn)) {
+      setColumnFilterFns((prev) => ({
+        ...prev,
+        [header.id]: allowedColumnFilterOptions?.[0] ?? 'fuzzy',
+      }));
+    }
   };
 
   const handleFilterByColumn = () => {
@@ -206,25 +213,23 @@ export const MRT_ColumnActionMenu = <TData extends MRT_RowData>({
       : []),
     ...(enableColumnFilters && column.getCanFilter()
       ? [
-          !['empty', 'notEmpty'].includes(columnDef._filterFn) && (
-            <MenuItem
-              disabled={
-                !columnFilterValue ||
-                (Array.isArray(columnFilterValue) &&
-                  !columnFilterValue.filter((value) => value).length)
-              }
-              key={3}
-              onClick={handleClearFilter}
-              sx={commonMenuItemStyles}
-            >
-              <Box sx={commonListItemStyles}>
-                <ListItemIcon>
-                  <FilterListOffIcon />
-                </ListItemIcon>
-                {localization.clearFilter}
-              </Box>
-            </MenuItem>
-          ),
+          <MenuItem
+            disabled={
+              !columnFilterValue ||
+              (Array.isArray(columnFilterValue) &&
+                !columnFilterValue.filter((value) => value).length)
+            }
+            key={3}
+            onClick={handleClearFilter}
+            sx={commonMenuItemStyles}
+          >
+            <Box sx={commonListItemStyles}>
+              <ListItemIcon>
+                <FilterListOffIcon />
+              </ListItemIcon>
+              {localization.clearFilter}
+            </Box>
+          </MenuItem>,
           columnFilterDisplayMode === 'subheader' && (
             <MenuItem
               disabled={showColumnFilters && !enableColumnFilterModes}

--- a/packages/material-react-table/src/types.ts
+++ b/packages/material-react-table/src/types.ts
@@ -105,12 +105,12 @@ export type MRT_RowSelectionState = RowSelectionState;
 export type MRT_SortingState = SortingState;
 export type MRT_Updater<T> = Updater<T>;
 export type MRT_VirtualItem = VirtualItem;
+export type MRT_VisibilityState = VisibilityState;
 
 export type MRT_VirtualizerOptions<
   TScrollElement extends Element | Window = Element | Window,
   TItemElement extends Element = Element,
 > = VirtualizerOptions<TScrollElement, TItemElement>;
-export type MRT_VisibilityState = VisibilityState;
 
 export type MRT_ColumnVirtualizer<
   TScrollElement extends Element | Window = HTMLDivElement,


### PR DESCRIPTION
If a filter fns empty or notEmpty is used, the option clear filter in menu dont need show. The bug founded if select empty, because filter value is a space char