### PR TITLE
Example: feat - grouping with single group column

### DIFF
--- a/apps/material-react-table-docs/components/prop-tables/stateOptions.ts
+++ b/apps/material-react-table-docs/components/prop-tables/stateOptions.ts
@@ -13,6 +13,15 @@ export type StateOption = {
 export const stateOptions: StateOption[] = [
   {
     defaultValue: '',
+    description: 'a variable will be used to render the leaf node.',
+    link: '',
+    linkText: '',
+    source: 'MRT',
+    stateOption: 'addColumnToLeafNode',
+    type: 'string',
+  },
+  {
+    defaultValue: '',
     description: 'a variable representing the currently creating row',
     link: '',
     linkText: '',

--- a/apps/material-react-table-docs/components/prop-tables/tableOptions.ts
+++ b/apps/material-react-table-docs/components/prop-tables/tableOptions.ts
@@ -358,6 +358,17 @@ export const tableOptions: TableOption[] = [
     type: 'boolean',
   },
   {
+    tableOption: 'enableGroupingSingleColumn',
+    defaultValue: '',
+    description:
+      'Single group column is automatically added by the grid containing all row groups under a single row group hierarchy.',
+    link: '',
+    linkText: '',
+    required: false,
+    source: 'MRT',
+    type: 'boolean',
+  },
+  {
     tableOption: 'enableFacetedValues',
     defaultValue: 'true',
     description:
@@ -2059,6 +2070,17 @@ export const tableOptions: TableOption[] = [
     required: false,
     source: 'TanStack Table',
     type: 'Record<string, SortingFn>',
+  },
+  {
+    tableOption: 'showOpenedGroup',
+    defaultValue: '',
+    description:
+      'This option will show the name of the opened group inside the group column.',
+    link: '',
+    linkText: '',
+    required: false,
+    source: 'MRT',
+    type: 'boolean',
   },
   {
     tableOption: 'state',

--- a/packages/material-react-table/src/hooks/useMRT_DisplayColumns.tsx
+++ b/packages/material-react-table/src/hooks/useMRT_DisplayColumns.tsx
@@ -69,8 +69,10 @@ export const useMRT_DisplayColumns = <TData extends MRT_RowData>(
       tableOptions.renderDetailPanel,
       tableOptions.renderRowActionMenuItems,
       tableOptions.renderRowActions,
+      tableOptions.state?.addColumnToLeafNode,
       tableOptions.state?.columnOrder,
       tableOptions.state?.grouping,
+      tableOptions.showOpenedGroup,
     ],
   );
 };

--- a/packages/material-react-table/src/hooks/useMRT_DisplayColumns.tsx
+++ b/packages/material-react-table/src/hooks/useMRT_DisplayColumns.tsx
@@ -171,7 +171,10 @@ function makeRowExpandColumn<TData extends MRT_RowData>(
               tableOptions?.showOpenedGroup &&
               !row.getCanExpand() &&
               row.original?.[
-                table.getState().grouping[table.getState().grouping.length - 1]
+                table.getState().addColumnToLeafNode ??
+                  table.getState().grouping[
+                    table.getState().grouping.length - 1
+                  ]
               ]}
           </>
         );

--- a/packages/material-react-table/src/hooks/useMRT_DisplayColumns.tsx
+++ b/packages/material-react-table/src/hooks/useMRT_DisplayColumns.tsx
@@ -190,8 +190,12 @@ function makeRowExpandColumn<TData extends MRT_RowData>(
               <MRT_ExpandAllButton table={table} />
             )}
             {tableOptions?.enableGroupingSingleColumn &&
-              tableOptions?.groupedColumnMode === 'remove' &&
-              'Group'}
+            tableOptions?.groupedColumnMode === 'remove'
+              ? table.getState().addColumnToLeafNode
+                ? table.getColumn?.(table.getState().addColumnToLeafNode ?? '')
+                    ?.columnDef?.header
+                : 'Group' /* Add key localization */
+              : undefined}
           </>
         );
       },

--- a/packages/material-react-table/src/hooks/useMRT_DisplayColumns.tsx
+++ b/packages/material-react-table/src/hooks/useMRT_DisplayColumns.tsx
@@ -166,6 +166,13 @@ function makeRowExpandColumn<TData extends MRT_RowData>(
             {tableOptions?.enableGroupingSingleColumn &&
               tableOptions?.groupedColumnMode === 'remove' &&
               row.groupingValue}
+            {tableOptions?.enableGroupingSingleColumn &&
+              tableOptions?.groupedColumnMode === 'remove' &&
+              tableOptions?.showOpenedGroup &&
+              !row.getCanExpand() &&
+              row.original?.[
+                table.getState().grouping[table.getState().grouping.length - 1]
+              ]}
           </>
         );
       },

--- a/packages/material-react-table/src/hooks/useMRT_DisplayColumns.tsx
+++ b/packages/material-react-table/src/hooks/useMRT_DisplayColumns.tsx
@@ -160,12 +160,12 @@ function makeRowExpandColumn<TData extends MRT_RowData>(
     order.includes(id) &&
     showExpandColumn(tableOptions, tableOptions.state?.grouping ?? grouping)
   ) {
+    const arrGrouping = tableOptions.state?.grouping ?? grouping;
     return {
       Cell: ({ row, table }) => {
         const isGroupedSingleColumn =
           tableOptions?.enableGroupingSingleColumn &&
           tableOptions?.groupedColumnMode === 'remove';
-
         return (
           <>
             <MRT_ExpandButton row={row} table={table} />
@@ -178,9 +178,7 @@ function makeRowExpandColumn<TData extends MRT_RowData>(
               !row.getCanExpand() &&
               row.original?.[
                 table.getState().addColumnToLeafNode ??
-                  table.getState().grouping[
-                    table.getState().grouping.length - 1
-                  ]
+                  arrGrouping[arrGrouping.length - 1]
               ]}
           </>
         );

--- a/packages/material-react-table/src/hooks/useMRT_DisplayColumns.tsx
+++ b/packages/material-react-table/src/hooks/useMRT_DisplayColumns.tsx
@@ -56,6 +56,7 @@ export const useMRT_DisplayColumns = <TData extends MRT_RowData>(
       tableOptions.enableEditing,
       tableOptions.enableExpandAll,
       tableOptions.enableExpanding,
+      tableOptions.enableGroupingSingleColumn,
       tableOptions.enableGrouping,
       tableOptions.enableRowActions,
       tableOptions.enableRowDragging,
@@ -158,10 +159,28 @@ function makeRowExpandColumn<TData extends MRT_RowData>(
     showExpandColumn(tableOptions, tableOptions.state?.grouping ?? grouping)
   ) {
     return {
-      Cell: ({ row, table }) => <MRT_ExpandButton row={row} table={table} />,
-      Header: tableOptions.enableExpandAll
-        ? ({ table }) => <MRT_ExpandAllButton table={table} />
-        : undefined,
+      Cell: ({ row, table }) => {
+        return (
+          <>
+            <MRT_ExpandButton row={row} table={table} />
+            {tableOptions?.enableGroupingSingleColumn &&
+              tableOptions?.groupedColumnMode === 'remove' &&
+              row.groupingValue}
+          </>
+        );
+      },
+      Header: ({ table }) => {
+        return (
+          <>
+            {tableOptions.enableExpandAll && (
+              <MRT_ExpandAllButton table={table} />
+            )}
+            {tableOptions?.enableGroupingSingleColumn &&
+              tableOptions?.groupedColumnMode === 'remove' &&
+              'Group'}
+          </>
+        );
+      },
       ...defaultDisplayColumnProps(tableOptions, id, 'expand'),
     };
   }

--- a/packages/material-react-table/src/hooks/useMRT_DisplayColumns.tsx
+++ b/packages/material-react-table/src/hooks/useMRT_DisplayColumns.tsx
@@ -160,14 +160,18 @@ function makeRowExpandColumn<TData extends MRT_RowData>(
   ) {
     return {
       Cell: ({ row, table }) => {
+        const isGroupedSingleColumn =
+          tableOptions?.enableGroupingSingleColumn &&
+          tableOptions?.groupedColumnMode === 'remove';
+
         return (
           <>
             <MRT_ExpandButton row={row} table={table} />
-            {tableOptions?.enableGroupingSingleColumn &&
-              tableOptions?.groupedColumnMode === 'remove' &&
-              row.groupingValue}
-            {tableOptions?.enableGroupingSingleColumn &&
-              tableOptions?.groupedColumnMode === 'remove' &&
+            {isGroupedSingleColumn && row.groupingValue}
+            {isGroupedSingleColumn && row.getCanExpand() && (
+              <> ({row.subRows?.length})</>
+            )}
+            {isGroupedSingleColumn &&
               tableOptions?.showOpenedGroup &&
               !row.getCanExpand() &&
               row.original?.[

--- a/packages/material-react-table/src/types.ts
+++ b/packages/material-react-table/src/types.ts
@@ -1201,9 +1201,9 @@ export type MRT_TableOptions<TData extends MRT_RowData> = Omit<
       }) => Partial<VirtualizerOptions<HTMLDivElement, HTMLTableRowElement>>)
     | Partial<VirtualizerOptions<HTMLDivElement, HTMLTableRowElement>>;
   selectAllMode?: 'all' | 'page';
+  showOpenedGroup?: boolean;
   /**
    * Manage state externally any way you want, then pass it back into MRT.
    */
-  showOpenedGroup?: boolean;
   state?: Partial<MRT_TableState<TData>>;
 };

--- a/packages/material-react-table/src/types.ts
+++ b/packages/material-react-table/src/types.ts
@@ -1203,5 +1203,6 @@ export type MRT_TableOptions<TData extends MRT_RowData> = Omit<
   /**
    * Manage state externally any way you want, then pass it back into MRT.
    */
+  showOpenedGroup?: boolean;
   state?: Partial<MRT_TableState<TData>>;
 };

--- a/packages/material-react-table/src/types.ts
+++ b/packages/material-react-table/src/types.ts
@@ -808,6 +808,7 @@ export type MRT_TableOptions<TData extends MRT_RowData> = Omit<
   enableFullScreenToggle?: boolean;
   enableGlobalFilterModes?: boolean;
   enableGlobalFilterRankedResults?: boolean;
+  enableGroupingSingleColumn?: boolean;
   enablePagination?: boolean;
   enableRowActions?: boolean;
   enableRowDragging?: boolean;

--- a/packages/material-react-table/src/types.ts
+++ b/packages/material-react-table/src/types.ts
@@ -338,6 +338,7 @@ export type MRT_DefinedTableOptions<TData extends MRT_RowData> =
   };
 
 export type MRT_TableState<TData extends MRT_RowData> = TableState & {
+  addColumnToLeafNode?: string;
   columnFilterFns: MRT_ColumnFilterFnsState;
   creatingRow: MRT_Row<TData> | null;
   density: MRT_DensityState;

--- a/packages/material-react-table/stories/features/ColumnGrouping.stories.tsx
+++ b/packages/material-react-table/stories/features/ColumnGrouping.stories.tsx
@@ -290,48 +290,6 @@ export const GroupingWithSingleColumn = () => {
   const _columns = useMemo<MRT_ColumnDef<Person>[]>(
     () => [
       {
-        AggregatedCell: ({ row, table }) => {
-          const {
-            options: {
-              icons: { ExpandMoreIcon },
-            },
-          } = table;
-
-          if (!row.groupingColumnId || !row.groupingValue) {
-            return null;
-          }
-
-          return (
-            <Stack alignItems="center" flexDirection="row">
-              <IconButton
-                onClick={() => row.toggleExpanded(!row.getIsExpanded())}
-                size="small"
-              >
-                <ExpandMoreIcon
-                  style={{
-                    transform: `rotate(${!row.getIsExpanded() ? -90 : 0}deg)`,
-                  }}
-                />
-              </IconButton>
-              <Typography>{row.groupingValue as ReactNode}</Typography>
-            </Stack>
-          );
-        },
-        accessorKey: 'group',
-        columnDefType: 'display',
-        header: 'Group',
-        muiTableBodyCellProps: ({ row }) => {
-          return {
-            sx: {
-              justifyContent: 'left',
-              pl: `calc(${row.depth * 16}px)`,
-              textAlign: 'left',
-            },
-          };
-        },
-        visibleInShowHideMenu: false,
-      },
-      {
         accessorKey: 'firstName',
         header: 'First Name',
       },
@@ -361,35 +319,22 @@ export const GroupingWithSingleColumn = () => {
       data={data}
       displayColumnDefOptions={{
         'mrt-row-expand': {
-          enableHiding: false,
           visibleInShowHideMenu: false,
         },
       }}
       enableColumnDragging
       enableGrouping
+      enableGroupingSingleColumn
       groupedColumnMode="remove"
       initialState={{
-        columnVisibility: { 'mrt-row-expand': false },
         density: 'compact',
         grouping: ['gender', 'state'],
-      }}
-      muiTableBodyRowProps={({ row }) => {
-        return {
-          sx: {
-            bgcolor:
-              row.groupingColumnId === 'gender'
-                ? 'darkgreen'
-                : row.groupingColumnId === 'state'
-                  ? 'slategrey'
-                  : 'inherit',
-          },
-        };
       }}
     />
   );
 };
 
-export const GroupingWithSingleColumnTest = () => {
+export const GroupingWithSingleColumnWithShowOpenedGroup = () => {
   const _columns = useMemo<MRT_ColumnDef<Person>[]>(
     () => [
       {
@@ -420,16 +365,87 @@ export const GroupingWithSingleColumnTest = () => {
     <MaterialReactTable
       columns={_columns}
       data={data}
+      displayColumnDefOptions={{
+        'mrt-row-expand': {
+          visibleInShowHideMenu: false,
+        },
+      }}
       enableColumnDragging
-      // enableExpandAll={false}
       enableGrouping
       enableGroupingSingleColumn
       groupedColumnMode="remove"
       initialState={{
-        addColumnToLeafNode: 'firstName',
+        addColumnToLeafNode: 'city',
+        columnVisibility: { city: false },
         density: 'compact',
         grouping: ['gender', 'state'],
       }}
+      showOpenedGroup
+    />
+  );
+};
+
+export const GroupingWithSingleColumnWithRowVirtualization = () => {
+  const _columns = useMemo<MRT_ColumnDef<Person>[]>(
+    () => [
+      {
+        accessorKey: 'firstName',
+        header: 'First Name',
+      },
+      {
+        accessorKey: 'lastName',
+        header: 'Last Name',
+      },
+      {
+        accessorKey: 'gender',
+        header: 'Gender',
+      },
+      {
+        accessorKey: 'city',
+        header: 'City',
+      },
+      {
+        accessorKey: 'state',
+        header: 'State',
+      },
+    ],
+    [],
+  );
+
+  return (
+    <MaterialReactTable
+      columns={_columns}
+      data={data}
+      displayColumnDefOptions={{
+        'mrt-row-expand': {
+          visibleInShowHideMenu: false,
+        },
+      }}
+      enableColumnDragging
+      enableGrouping
+      enableGroupingSingleColumn
+      enablePagination={false}
+      enableRowVirtualization
+      groupedColumnMode="remove"
+      initialState={{
+        addColumnToLeafNode: 'city',
+        columnVisibility: { city: false },
+        density: 'compact',
+        grouping: ['gender', 'state'],
+      }}
+      muiTableBodyRowProps={({ row }) => {
+        return {
+          sx: {
+            bgcolor:
+              row.depth === 0
+                ? 'darkgreen'
+                : row.depth === 1
+                  ? 'slategrey'
+                  : 'inherit',
+          },
+        };
+      }}
+      muiTableContainerProps={{ sx: { maxHeight: 600 } }}
       showOpenedGroup
     />
   );

--- a/packages/material-react-table/stories/features/ColumnGrouping.stories.tsx
+++ b/packages/material-react-table/stories/features/ColumnGrouping.stories.tsx
@@ -429,6 +429,7 @@ export const GroupingWithSingleColumnTest = () => {
         density: 'compact',
         grouping: ['gender', 'state'],
       }}
+      showOpenedGroup
     />
   );
 };

--- a/packages/material-react-table/stories/features/ColumnGrouping.stories.tsx
+++ b/packages/material-react-table/stories/features/ColumnGrouping.stories.tsx
@@ -1,4 +1,7 @@
-import { useEffect, useMemo, useState } from 'react';
+import { type ReactNode, useEffect, useMemo, useState } from 'react';
+import IconButton from '@mui/material/IconButton';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
 import {
   type MRT_Column,
   type MRT_ColumnDef,
@@ -278,6 +281,97 @@ export const GroupingAndDraggingWithSomeDisabledGrouping = () => {
       data={data}
       enableColumnDragging
       enableGrouping
+    />
+  );
+};
+
+export const GroupingWithSingleColumn = () => {
+  const _columns = useMemo<MRT_ColumnDef<Person>[]>(
+    () => [
+      {
+        AggregatedCell: ({ row, table }) => {
+          const {
+            options: {
+              icons: { ExpandMoreIcon },
+            },
+          } = table;
+
+          if (!row.groupingColumnId || !row.groupingValue) {
+            return null;
+          }
+
+          return (
+            <Stack alignItems="center" flexDirection="row">
+              <IconButton
+                onClick={() => row.toggleExpanded(!row.getIsExpanded())}
+                size="small"
+              >
+                <ExpandMoreIcon
+                  style={{
+                    transform: `rotate(${!row.getIsExpanded() ? -90 : 0}deg)`,
+                  }}
+                />
+              </IconButton>
+              <Typography>{row.groupingValue as ReactNode}</Typography>
+            </Stack>
+          );
+        },
+        accessorKey: 'group',
+        columnDefType: 'display',
+        header: 'Group',
+        muiTableBodyCellProps: ({ row }) => {
+          return {
+            sx: {
+              justifyContent: 'left',
+              pl: `calc(${row.depth * 16}px)`,
+              textAlign: 'left',
+            },
+          };
+        },
+        visibleInShowHideMenu: false,
+      },
+      {
+        accessorKey: 'firstName',
+        header: 'First Name',
+      },
+      {
+        accessorKey: 'lastName',
+        header: 'Last Name',
+      },
+      {
+        accessorKey: 'gender',
+        header: 'Gender',
+      },
+      {
+        accessorKey: 'city',
+        header: 'City',
+      },
+      {
+        accessorKey: 'state',
+        header: 'State',
+      },
+    ],
+    [],
+  );
+
+  return (
+    <MaterialReactTable
+      columns={_columns}
+      data={data}
+      displayColumnDefOptions={{
+        'mrt-row-expand': {
+          enableHiding: false,
+          visibleInShowHideMenu: false,
+        },
+      }}
+      enableColumnDragging
+      enableGrouping
+      groupedColumnMode="remove"
+      initialState={{
+        columnVisibility: { 'mrt-row-expand': false },
+        density: 'compact',
+        grouping: ['gender', 'state'],
+      }}
     />
   );
 };

--- a/packages/material-react-table/stories/features/ColumnGrouping.stories.tsx
+++ b/packages/material-react-table/stories/features/ColumnGrouping.stories.tsx
@@ -426,6 +426,7 @@ export const GroupingWithSingleColumnTest = () => {
       enableGroupingSingleColumn
       groupedColumnMode="remove"
       initialState={{
+        addColumnToLeafNode: 'firstName',
         density: 'compact',
         grouping: ['gender', 'state'],
       }}

--- a/packages/material-react-table/stories/features/ColumnGrouping.stories.tsx
+++ b/packages/material-react-table/stories/features/ColumnGrouping.stories.tsx
@@ -5,6 +5,7 @@ import Typography from '@mui/material/Typography';
 import {
   type MRT_Column,
   type MRT_ColumnDef,
+  type MRT_Row,
   MaterialReactTable,
 } from '../../src';
 import { faker } from '@faker-js/faker';
@@ -371,6 +372,18 @@ export const GroupingWithSingleColumn = () => {
         columnVisibility: { 'mrt-row-expand': false },
         density: 'compact',
         grouping: ['gender', 'state'],
+      }}
+      muiTableBodyRowProps={({ row }) => {
+        return {
+          sx: {
+            bgcolor:
+              row.groupingColumnId === 'gender'
+                ? 'darkgreen'
+                : row.groupingColumnId === 'state'
+                  ? 'slategrey'
+                  : 'inherit',
+          },
+        };
       }}
     />
   );

--- a/packages/material-react-table/stories/features/ColumnGrouping.stories.tsx
+++ b/packages/material-react-table/stories/features/ColumnGrouping.stories.tsx
@@ -388,3 +388,47 @@ export const GroupingWithSingleColumn = () => {
     />
   );
 };
+
+export const GroupingWithSingleColumnTest = () => {
+  const _columns = useMemo<MRT_ColumnDef<Person>[]>(
+    () => [
+      {
+        accessorKey: 'firstName',
+        header: 'First Name',
+      },
+      {
+        accessorKey: 'lastName',
+        header: 'Last Name',
+      },
+      {
+        accessorKey: 'gender',
+        header: 'Gender',
+      },
+      {
+        accessorKey: 'city',
+        header: 'City',
+      },
+      {
+        accessorKey: 'state',
+        header: 'State',
+      },
+    ],
+    [],
+  );
+
+  return (
+    <MaterialReactTable
+      columns={_columns}
+      data={data}
+      enableColumnDragging
+      // enableExpandAll={false}
+      enableGrouping
+      enableGroupingSingleColumn
+      groupedColumnMode="remove"
+      initialState={{
+        density: 'compact',
+        grouping: ['gender', 'state'],
+      }}
+    />
+  );
+};


### PR DESCRIPTION
Hello @KevinVandy,

Currently, there is no single column group feature, I have made an example in the storybook.

Could you develop this into a library feature?

Reference: https://www.ag-grid.com/react-data-grid/grouping-single-group-column/