### PR TITLE
Fixed space char after change from empty filter to equal, contains fi…

### DIFF
--- a/packages/material-react-table/src/menus/MRT_FilterOptionMenu.tsx
+++ b/packages/material-react-table/src/menus/MRT_FilterOptionMenu.tsx
@@ -220,6 +220,9 @@ export const MRT_FilterOptionMenu = <TData extends MRT_RowData>({
         if (Array.isArray(currentFilterValue)) {
           column.setFilterValue('');
           setFilterValue?.('');
+        } else if (currentFilterValue === ' ' &&
+          emptyModes.includes(prevFilterMode)) {
+          column.setFilterValue(undefined);
         } else {
           column.setFilterValue(currentFilterValue); // perform new filter render
         }


### PR DESCRIPTION
…lter

After change column filter to empty, a space added on filterValue. Change filter to another filter (example equal, contains), the space char dont is cleaned. This fixed to detect if the previous select filter are a emptyMode and the filterValue are a space char. If yes, clear the value.