### PR TITLE
Changed guide for customizing components to include reference to cust…

### DIFF
--- a/apps/material-react-table-docs/pages/docs/guides/customize-components.mdx
+++ b/apps/material-react-table-docs/pages/docs/guides/customize-components.mdx
@@ -330,3 +330,17 @@ const table = useMaterialReactTable({
 ```
 
 <CustomizeStylesExample />
+
+### Customize No Rows overlay
+
+As part of the customization options, we allow you to override the No Records overlay.
+
+```jsx
+const table = useMaterialReactTable({
+  columns,
+  data,
+  renderEmptyRowsFallback: ({table}) => (
+    <span>Customized No Rows Overlay</span>
+  )
+});
+```


### PR DESCRIPTION
Provided example on how to customize the no rows overlay, hopefully makes it easier for users migrating from https://mui.com/x/react-data-grid/components/#no-rows-overlay to move over to this project.

Updated the mdx guide, so that users are now able to discover that `renderEmptyRowsFallback` exists. Previously there was no mention of it when I searched the docs for that or No Rows Overlay.

Did not add an example, because I wasn't able to figure out how to do that.