### PR TITLE
Fix typo in about.mdx

### DIFF
--- a/apps/material-react-table-docs/pages/about.mdx
+++ b/apps/material-react-table-docs/pages/about.mdx
@@ -20,7 +20,7 @@ Material React Table (MRT) is a fully-featured data grid/table component library
 
 If you are a Tailwind or native CSS user, check out [Mantine React Table](https://www.mantine-react-table.com) instead, which is a sister library to MRT that uses [Mantine](https://mantine.dev) components instead of Material UI and is a bit more Tailwind friendly.
 
-MRT is built from the ground up in TypeScript, and is designed to have a great type-safe dev experience with generics that react to the data structures you pass in. TypeScript is not at all required to use MRT, but it is recommended for the best and fasted developer experience, especially when defining columns.
+MRT is built from the ground up in TypeScript, and is designed to have a great type-safe dev experience with generics that react to the data structures you pass in. TypeScript is not at all required to use MRT, but it is recommended for the best and fastest developer experience, especially when defining columns.
 
 > Material React Table has a sister library, [Mantine React Table](https://www.mantine-react-table.com) that uses [Mantine](https://mantine.dev) components instead of Material UI, but otherwise has the same API. Check it out if you're looking for a Material UI alternative.
 


### PR DESCRIPTION
"best and fasted" -> "best and fastest"