### PR TITLE
Toggle all columns visible issue fixed

### DIFF
--- a/packages/material-react-table/src/components/menus/MRT_ColumnActionMenu.tsx
+++ b/packages/material-react-table/src/components/menus/MRT_ColumnActionMenu.tsx
@@ -26,6 +26,7 @@ export const MRT_ColumnActionMenu = <TData extends MRT_RowData>({
 }: Props<TData>) => {
   const {
     getState,
+    getAllLeafColumns,
     options: {
       columnFilterDisplayMode,
       columnFilterModeOptions,
@@ -56,7 +57,6 @@ export const MRT_ColumnActionMenu = <TData extends MRT_RowData>({
     setColumnOrder,
     setColumnSizingInfo,
     setShowColumnFilters,
-    toggleAllColumnsVisible,
   } = table;
   const { column } = header;
   const { columnDef } = column;
@@ -122,7 +122,9 @@ export const MRT_ColumnActionMenu = <TData extends MRT_RowData>({
   };
 
   const handleShowAllColumns = () => {
-    toggleAllColumnsVisible(true);
+    getAllLeafColumns()
+      .filter((col) => col.columnDef.enableHiding !== false)
+      .forEach((col) => col.toggleVisibility(true));
     setAnchorEl(null);
   };
 

--- a/packages/material-react-table/stories/features/ColumnHiding.stories.tsx
+++ b/packages/material-react-table/stories/features/ColumnHiding.stories.tsx
@@ -203,3 +203,42 @@ export const ColumnHidingColumnsNotVisibleInShowHide = () => (
     data={data}
   />
 );
+export const ColumnHidingWithColumnsHiddenAndNotVisibleInShowHide = () => (
+  <MaterialReactTable
+    columns={[
+      {
+        accessorKey: 'firstName',
+        header: 'First Name',
+      },
+      {
+        accessorKey: 'lastName',
+        header: 'Last Name',
+      },
+      {
+        accessorKey: 'address',
+        header: 'Address',
+        visibleInShowHideMenu: false,
+      },
+      {
+        accessorKey: 'state',
+        header: 'State',
+      },
+      {
+        accessorKey: 'zip',
+        header: 'Zip',
+      },
+      {
+        accessorKey: 'email',
+        header: 'Email Address',
+      },
+      {
+        accessorKey: 'phoneNumber',
+        header: 'Phone Number',
+      },
+    ]}
+    data={data}
+    initialState={{
+      columnVisibility: { address: false }
+    }}
+  />
+);

--- a/packages/material-react-table/stories/features/ColumnHiding.stories.tsx
+++ b/packages/material-react-table/stories/features/ColumnHiding.stories.tsx
@@ -218,6 +218,7 @@ export const ColumnHidingWithColumnsHiddenAndNotVisibleInShowHide = () => (
         accessorKey: 'address',
         header: 'Address',
         visibleInShowHideMenu: false,
+        enableHiding: false,
       },
       {
         accessorKey: 'state',


### PR DESCRIPTION
This PR fixes issue #965. Also adds a new Storybook example showcasing what happens when you use column hiding with columns that are hidden and are not visible in the "Show/Hide" menu that was introducted in [v2.3.0](https://github.com/KevinVandy/material-react-table/releases/tag/v2.3.0).