### PR TITLE
fix: wrong field used in example

### DIFF
--- a/apps/material-react-table-docs/pages/docs/guides/editing.mdx
+++ b/apps/material-react-table-docs/pages/docs/guides/editing.mdx
@@ -124,7 +124,7 @@ const table = useMaterialReactTable({
   data,
   enableEditing: true,
   editDisplayMode: 'modal', //default
-  onCreatingRowSave: ({ table, values }) => {
+  onEditingRowSave: ({ table, values }) => {
     //validate data
     //save data to api
     table.setEditingRow(null); //exit editing mode


### PR DESCRIPTION
Section explains on editing data but example used `onCreatingRowSave` as example. The previous passage that mentions `onEditingRowSave` also points out that this is a small typo on the guide example.