### PR TITLE
Fix dnd ghost going back on drop

### DIFF
--- a/packages/material-react-table/src/components/body/MRT_TableBodyCell.tsx
+++ b/packages/material-react-table/src/components/body/MRT_TableBodyCell.tsx
@@ -210,6 +210,10 @@ export const MRT_TableBodyCell = <TData extends MRT_RowData>({
     }
   };
 
+  const handleDragOver = (e: DragEvent) => {
+    e.preventDefault();
+  };
+
   const handleContextMenu = (e: MouseEvent<HTMLTableCellElement>) => {
     tableCellProps?.onContextMenu?.(e);
     if (isRightClickable) {
@@ -228,6 +232,7 @@ export const MRT_TableBodyCell = <TData extends MRT_RowData>({
       onContextMenu={handleContextMenu}
       onDoubleClick={handleDoubleClick}
       onDragEnter={handleDragEnter}
+      onDragOver={handleDragOver}
       sx={(theme) => ({
         '&:hover': {
           outline:

--- a/packages/material-react-table/src/components/body/MRT_TableBodyRow.tsx
+++ b/packages/material-react-table/src/components/body/MRT_TableBodyRow.tsx
@@ -140,6 +140,10 @@ export const MRT_TableBodyRow = <TData extends MRT_RowData>({
     }
   };
 
+  const handleDragOver = (e: DragEvent) => {
+    e.preventDefault();
+  };
+
   const rowRef = useRef<HTMLTableRowElement | null>(null);
 
   const cellHighlightColor = isRowSelected
@@ -164,6 +168,7 @@ export const MRT_TableBodyRow = <TData extends MRT_RowData>({
         data-pinned={!!isRowPinned || undefined}
         data-selected={isRowSelected || undefined}
         onDragEnter={handleDragEnter}
+        onDragOver={handleDragOver}
         ref={(node: HTMLTableRowElement) => {
           if (node) {
             rowRef.current = node;

--- a/packages/material-react-table/src/components/head/MRT_TableHeadCell.tsx
+++ b/packages/material-react-table/src/components/head/MRT_TableHeadCell.tsx
@@ -141,6 +141,10 @@ export const MRT_TableHeadCell = <TData extends MRT_RowData>({
     }
   };
 
+  const handleDragOver = (e: DragEvent) => {
+    e.preventDefault();
+  };
+
   const HeaderElement =
     parseFromValuesOrFunc(columnDef.Header, {
       column,
@@ -161,6 +165,7 @@ export const MRT_TableHeadCell = <TData extends MRT_RowData>({
       data-index={staticColumnIndex}
       data-pinned={!!isColumnPinned || undefined}
       onDragEnter={handleDragEnter}
+      onDragOver={handleDragOver}
       ref={(node: HTMLTableCellElement) => {
         if (node) {
           tableHeadCellRefs.current[column.id] = node;

--- a/packages/material-react-table/src/components/toolbar/MRT_ToolbarDropZone.tsx
+++ b/packages/material-react-table/src/components/toolbar/MRT_ToolbarDropZone.tsx
@@ -29,6 +29,10 @@ export const MRT_ToolbarDropZone = <TData extends MRT_RowData>({
     setHoveredColumn({ id: 'drop-zone' });
   };
 
+  const handleDragOver = (e: DragEvent) => {
+    e.preventDefault();
+  };
+
   useEffect(() => {
     if (table.options.state?.showToolbarDropZone !== undefined) {
       setShowToolbarDropZone(
@@ -45,6 +49,7 @@ export const MRT_ToolbarDropZone = <TData extends MRT_RowData>({
       <Box
         className="Mui-ToolbarDropZone"
         onDragEnter={handleDragEnter}
+        onDragOver={handleDragOver}
         {...rest}
         sx={(theme) => ({
           alignItems: 'center',


### PR DESCRIPTION
This is a small UX enhancment

When finishing a drop, it looks like the drag is not 'accepted' because the drag ghost 'goes back'

![mrt-drag-drop-ghost-issue](https://github.com/KevinVandy/material-react-table/assets/10304259/84ffac17-546d-4641-b49a-0e49d84ced30)

Please review