### PR TITLE
Update `useRef` types in virtualization.mdx#access-underlying-virtualizer-instances

### DIFF
--- a/apps/material-react-table-docs/pages/docs/guides/virtualization.mdx
+++ b/apps/material-react-table-docs/pages/docs/guides/virtualization.mdx
@@ -124,8 +124,8 @@ See the official TanStack [Virtualizer Options API Docs](https://tanstack.com/vi
 In a similar way that you can [access the underlying table instance](/docs/guides/table-state-management#access-the-underlying-table-instance-reference), you can also access the underlying virtualizer instances. This can be useful for accessing methods like the `scrollToIndex` method, which can be used to programmatically scroll to a specific row or column.
 
 ```tsx
-const columnVirtualizerInstanceRef = useRef<Virtualizer>(null);
-const rowVirtualizerInstanceRef = useRef<Virtualizer>(null);
+const columnVirtualizerInstanceRef = useRef<MRT_ColumnVirtualizer>(null);
+const rowVirtualizerInstanceRef = useRef<MRT_RowVirtualizer>(null);
 
 useEffect(() => {
   if (rowVirtualizerInstanceRef.current) {


### PR DESCRIPTION
Fix `useRef<Virtualizer>` to `useRef<MRT_ColumnVirtualizer>` and `useRef<MRT_RowVirtualizer>`.