### PR TITLE
fix: column right pin ruins menu order

### DIFF
--- a/packages/material-react-table/src/components/menus/MRT_ShowHideColumnsMenu.tsx
+++ b/packages/material-react-table/src/components/menus/MRT_ShowHideColumnsMenu.tsx
@@ -63,7 +63,14 @@ export const MRT_ShowHideColumnsMenu = <TData extends MRT_RowData>({
           getCenterLeafColumns().find((col) => col?.id === colId),
         ),
         ...getRightLeafColumns(),
-      ].filter(Boolean);
+      ]
+        .filter(Boolean)
+        .sort((a, b) => {
+          return (
+            columnOrder.indexOf((a as MRT_Column<TData>).id) -
+            columnOrder.indexOf((b as MRT_Column<TData>).id)
+          );
+        });
     }
     return columns;
   }, [


### PR DESCRIPTION
column right pin pushes menu item to the bottom instead of keeping correct order

closes #1018