### PR TITLE
disable "save" button when "isSaving" is true

### DIFF
--- a/packages/material-react-table/src/components/buttons/MRT_EditActionButtons.tsx
+++ b/packages/material-react-table/src/components/buttons/MRT_EditActionButtons.tsx
@@ -106,6 +106,7 @@ export const MRT_EditActionButtons = <TData extends MRT_RowData>({
                 aria-label={localization.save}
                 color="info"
                 onClick={handleSubmitRow}
+                disabled={isSaving}
               >
                 {isSaving ? <CircularProgress size={18} /> : <SaveIcon />}
               </IconButton>
@@ -121,6 +122,7 @@ export const MRT_EditActionButtons = <TData extends MRT_RowData>({
             onClick={handleSubmitRow}
             sx={{ minWidth: '100px' }}
             variant="contained"
+            disabled={isSaving}
           >
             {isSaving && <CircularProgress color="inherit" size={18} />}
             {localization.save}


### PR DESCRIPTION
This addition would allow for developers to prevent users from submitting the same edit/new row twice when the click the "save" button multiple times. It makes use rarely-used of the `isSaving` state of the table to disable the "save" button. Should be very useful for developers who make use of async CRUD data.

All developers would have to do is set the `isSaving` state to true at the start of the `onEditingRowSave`/`onCreatingRowSave` function, and once their async calls are finished, they set it back to false.

This PR was based off of the idea proposed in [this discord message](https://discord.com/channels/937072769831694406/937078779283656724/1214290347786502234).