### PR TITLE
fix:[#1046] Sub Row Selection not working correctly

### DIFF
--- a/packages/material-react-table/src/utils/row.utils.ts
+++ b/packages/material-react-table/src/utils/row.utils.ts
@@ -131,11 +131,13 @@ export const getIsRowSelected = <TData extends MRT_RowData>({
   table: MRT_TableInstance<TData>;
 }) => {
   const {
-    options: { enableRowSelection },
+    options: { enableRowSelection, enableSubRowSelection },
   } = table;
 
   return (
-    row.getIsSelected() ||
+    (enableSubRowSelection
+      ? row.getIsSelected() && !row.getCanExpand()
+      : row.getIsSelected()) ||
     (parseFromValuesOrFunc(enableRowSelection, row) &&
       row.getCanSelectSubRows() &&
       row.getIsAllSubRowsSelected())


### PR DESCRIPTION
Now, after selecting all subrows by clicking on the group header, deselecting individual subrows will correctly update the group header's checkbox status.





