### PR TITLE
fix(docs/index): overflow issue in install command

### DIFF
--- a/apps/material-react-table-docs/components/mdx/InstallCommand.tsx
+++ b/apps/material-react-table-docs/components/mdx/InstallCommand.tsx
@@ -31,6 +31,11 @@ export const InstallCommand = ({
         className="language-bash"
         margin="0"
         style={{ overflowX: 'hidden' }}
+        paperSxProps={{
+          '& .token-line': {
+            overflowX: 'auto',
+          },
+        }}
       >
         {tab === 'npm'
           ? `npm i ${packagesString}`

--- a/apps/material-react-table-docs/components/mdx/SampleCodeSnippet.tsx
+++ b/apps/material-react-table-docs/components/mdx/SampleCodeSnippet.tsx
@@ -6,6 +6,8 @@ import {
   styled,
   alpha,
   Paper,
+  type SxProps,
+  type Theme,
 } from '@mui/material';
 import { Highlight, themes } from 'prism-react-renderer';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
@@ -23,9 +25,10 @@ interface Props {
   enableCopyButton?: boolean;
   style?: CSSProperties;
   margin?: string;
+  paperSxProps?: SxProps<Theme>;
 }
 
-export const SampleCodeSnippet = (props: Props) => {
+export const SampleCodeSnippet = ({ paperSxProps, ...props }: Props) => {
   const theme = useTheme();
   const [isCopied, setIsCopied] = useState(false);
 
@@ -66,6 +69,7 @@ export const SampleCodeSnippet = (props: Props) => {
         boxShadow: props.enableCopyButton === false ? 'none' : undefined,
         backgroundImage: 'none',
         backgroundColor: 'transparent',
+        ...paperSxProps,
       }}
     >
       <Highlight


### PR DESCRIPTION
There seems to be an overflow issue for the  code-block for install commands.

I didn't know if it was okay to directly change the `<Highlight >` component in the `<SampleCodeSnippet>` component, so added an extra optional prop to extend the `sx` prop of the `<Paper>` component.

Original (material-react-table.com):
![image](https://github.com/KevinVandy/material-react-table/assets/22864071/5a7ff38d-d4db-49d6-a38d-07f0572f5861)

After fix:
![image](https://github.com/KevinVandy/material-react-table/assets/22864071/b6d06dac-299d-4926-bfd7-3313a05fb87d)
