### PR TITLE
Fix: allow reordering pinned columns

### DIFF
--- a/packages/material-react-table/src/components/head/MRT_TableHeadCellGrabHandle.tsx
+++ b/packages/material-react-table/src/components/head/MRT_TableHeadCellGrabHandle.tsx
@@ -5,7 +5,7 @@ import {
   type MRT_RowData,
   type MRT_TableInstance,
 } from '../../types';
-import { reorderColumn } from '../../utils/column.utils';
+import { reorderColumn, reorderColumnPinning } from '../../utils/column.utils';
 import { parseFromValuesOrFunc } from '../../utils/utils';
 import { MRT_GrabHandleButton } from '../buttons/MRT_GrabHandleButton';
 
@@ -28,9 +28,11 @@ export const MRT_TableHeadCellGrabHandle = <TData extends MRT_RowData>({
     setColumnOrder,
     setDraggingColumn,
     setHoveredColumn,
+    setColumnPinning,
   } = table;
   const { columnDef } = column;
-  const { columnOrder, draggingColumn, hoveredColumn } = getState();
+  const { columnOrder, draggingColumn, hoveredColumn, columnPinning } =
+    getState();
 
   const iconButtonProps = {
     ...parseFromValuesOrFunc(muiColumnDragHandleProps, { column, table }),
@@ -64,9 +66,27 @@ export const MRT_TableHeadCellGrabHandle = <TData extends MRT_RowData>({
       hoveredColumn &&
       hoveredColumn?.id !== draggingColumn?.id
     ) {
-      setColumnOrder(
-        reorderColumn(column, hoveredColumn as MRT_Column<TData>, columnOrder),
+      const newColumnOrder = reorderColumn(
+        column,
+        hoveredColumn as MRT_Column<TData>,
+        columnOrder,
       );
+
+      if (
+        hoveredColumn?.getIsPinned?.() &&
+        draggingColumn?.getIsPinned?.() &&
+        hoveredColumn?.id
+      ) {
+        const newColumnPinning = reorderColumnPinning(
+          column,
+          hoveredColumn as MRT_Column<TData>,
+          columnPinning,
+        );
+
+        setColumnPinning(newColumnPinning);
+      }
+
+      setColumnOrder(newColumnOrder);
     }
     setDraggingColumn(null);
     setHoveredColumn(null);

--- a/packages/material-react-table/src/components/menus/MRT_ShowHideColumnsMenuItems.tsx
+++ b/packages/material-react-table/src/components/menus/MRT_ShowHideColumnsMenuItems.tsx
@@ -16,7 +16,7 @@ import {
   type MRT_RowData,
   type MRT_TableInstance,
 } from '../../types';
-import { reorderColumn } from '../../utils/column.utils';
+import { reorderColumn, reorderColumnPinning } from '../../utils/column.utils';
 import { getCommonTooltipProps } from '../../utils/style.utils';
 import { parseFromValuesOrFunc } from '../../utils/utils';
 import { MRT_ColumnPinningButtons } from '../buttons/MRT_ColumnPinningButtons';
@@ -51,8 +51,9 @@ export const MRT_ShowHideColumnsMenuItems = <TData extends MRT_RowData>({
       mrtTheme: { draggingBorderColor },
     },
     setColumnOrder,
+    setColumnPinning,
   } = table;
-  const { columnOrder } = getState();
+  const { columnOrder, columnPinning } = getState();
   const { columnDef } = column;
   const { columnDefType } = columnDef;
 
@@ -86,6 +87,20 @@ export const MRT_ShowHideColumnsMenuItems = <TData extends MRT_RowData>({
     setHoveredColumn(null);
     if (hoveredColumn) {
       setColumnOrder(reorderColumn(column, hoveredColumn, columnOrder));
+
+      if (
+        hoveredColumn?.getIsPinned?.() &&
+        column?.getIsPinned?.() &&
+        hoveredColumn?.id
+      ) {
+        const newColumnPinning = reorderColumnPinning(
+          column,
+          hoveredColumn as MRT_Column<TData>,
+          columnPinning,
+        );
+
+        setColumnPinning(newColumnPinning);
+      }
     }
   };
 

--- a/packages/material-react-table/src/utils/utils.ts
+++ b/packages/material-react-table/src/utils/utils.ts
@@ -21,3 +21,17 @@ export const getValueAndLabel = (
   }
   return { label, value };
 };
+
+export function reorderArray<T>(
+  arr: T[],
+  sourceIndex: number,
+  destinationIndex: number,
+): T[] {
+  const reorderedArr = [...arr];
+  reorderedArr.splice(
+    destinationIndex,
+    0,
+    reorderedArr.splice(sourceIndex, 1)[0],
+  );
+  return reorderedArr;
+}


### PR DESCRIPTION
I noticed that while having `enableColumnOrdering`, `enableColumnPinning`, and `enableColumnDragging` enabled the reorder action didn't impact the order of the pinned columns from either the drag handle or from the columns menu.

Example:

https://github.com/KevinVandy/material-react-table/assets/79770577/8103e514-ced8-4a3d-97ed-64addcbd67b1


I had two approaches in mind to fix this
- Add a setState change in the event handler for `MRT_TableHeadCellGrabHandle` and `MRT_ShowHideColumnsMenuItems` to reorder the pins where appropriate (columns are able to pin and are pinned)
- Add some logic within TanStack table which reconciles column ordering and column pins so that both pinning positions reflect the same column id order as in the column order state.

I thought the second approach might be more appropriate to ensure this behavior works across other potential reorder actions, and so that the aforementioned components can remain simpler and just continue to call `setColumnOrder`.

However I wasn't able to find the best place in TanStack Table's source code to address this, so I opted to make the change seen in this PR. I'm very open to figuring out the change in TanStack if you agree that's a better place to fix it, and especially if you have some pointers on where I might look to investigate this behavior there.


An example, with this change applied:

https://github.com/KevinVandy/material-react-table/assets/79770577/4220cc55-7a31-4af9-8103-9e6116751755


I opted to not run this reordering when an unpinned column is dragged into the pinned column area, maintaining that action as just a form of calling `pin` on the column.
