### PR TITLE
docs: fix a typo in the documentation examples

### DIFF
--- a/apps/material-react-table-docs/components/prop-tables/tableOptions.ts
+++ b/apps/material-react-table-docs/components/prop-tables/tableOptions.ts
@@ -1071,7 +1071,7 @@ export const tableOptions: TableOption[] = [
     linkText: 'Memoize Components Guide',
     required: false,
     source: 'MRT',
-    type: `'cell' | 'row' | 'table-body'`,
+    type: `'cells' | 'rows' | 'table-body'`,
   },
   {
     tableOption: 'mergeOptions',

--- a/apps/material-react-table-docs/pages/docs/guides/memoization.mdx
+++ b/apps/material-react-table-docs/pages/docs/guides/memoization.mdx
@@ -149,7 +149,7 @@ const table = useMaterialReactTable({
   columns,
   data,
   //memoize all cells. This value can be applied dynamically based on a certain scenario/condition if needed
-  memoMode: 'cell', // 'cell' | 'row' | 'table-body'
+  memoMode: 'cells', // 'cells' | 'rows' | 'table-body'
 });
 ```
 


### PR DESCRIPTION
In the documentation: Update `memoMode` values from `'cell' | 'row' | 'table-body'` to `'cells' | 'rows' | 'table-body'` based on the type `MRT_ColumnDef` defined in `packages/material-react-table/src/types.ts`.