### PR TITLE
Don't double highlight nested tables

### DIFF
--- a/packages/material-react-table/src/components/body/MRT_TableBodyRow.tsx
+++ b/packages/material-react-table/src/components/body/MRT_TableBodyRow.tsx
@@ -184,7 +184,7 @@ export const MRT_TableBodyRow = <TData extends MRT_RowData>({
           ...tableRowProps?.style,
         }}
         sx={(theme: Theme) => ({
-          '&:hover td:after': cellHighlightColorHover
+          '&:hover > td:after': cellHighlightColorHover
             ? {
                 backgroundColor: alpha(cellHighlightColorHover, 0.3),
                 ...commonCellBeforeAfterStyles,

--- a/packages/material-react-table/stories/styling/TableBodyRowStyles.stories.tsx
+++ b/packages/material-react-table/stories/styling/TableBodyRowStyles.stories.tsx
@@ -24,8 +24,18 @@ const columns: MRT_ColumnDef<(typeof data)[0]>[] = [
   {
     accessorKey: 'address',
     header: 'Address',
+    Cell: ({ cell }) => (
+      <table>
+        <tbody>
+          <tr>
+            <td>{cell.getValue<string>()}</td>
+          </tr>
+        </tbody>
+      </table>
+    )
   },
 ];
+
 const data = [...Array(21)].map(() => ({
   address: faker.location.streetAddress(),
   age: faker.number.int(80),


### PR DESCRIPTION
The TableCel is double highlighted if there is a table in a cell. This pull request makes the highlight only apply to td's that are a direct child of tr.