### PR TITLE
Disable blur by pressing enter when composing

### DIFF
--- a/packages/material-react-table/src/components/inputs/MRT_EditCellTextField.tsx
+++ b/packages/material-react-table/src/components/inputs/MRT_EditCellTextField.tsx
@@ -42,6 +42,7 @@ export const MRT_EditCellTextField = <TData extends MRT_RowData>({
   const isEditing = editingRow?.id === row.id;
 
   const [value, setValue] = useState(() => cell.getValue<string>());
+  const [completesComposition, setCompletesComposition] = useState(true);
 
   const textFieldProps: TextFieldProps = {
     ...parseFromValuesOrFunc(muiEditTextFieldProps, {
@@ -94,7 +95,7 @@ export const MRT_EditCellTextField = <TData extends MRT_RowData>({
 
   const handleEnterKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
     textFieldProps.onKeyDown?.(event);
-    if (event.key === 'Enter' && !event.shiftKey) {
+    if (event.key === 'Enter' && !event.shiftKey && completesComposition) {
       editInputRefs.current[column.id]?.blur();
     }
   };
@@ -164,6 +165,8 @@ export const MRT_EditCellTextField = <TData extends MRT_RowData>({
         textFieldProps?.onClick?.(e);
       }}
       onKeyDown={handleEnterKeyDown}
+      onCompositionStart={() => setCompletesComposition(false)}
+      onCompositionEnd={() => setCompletesComposition(true)}
     >
       {textFieldProps.children ??
         selectOptions?.map((option) => {


### PR DESCRIPTION
- #1223 

Utilized MUI's onCompositionStart and onCompositionEnd:

- Maintains a state to track whether the composition is complete.
- Sets the state to false when composition starts.
- Sets the state to true when composition ends.
- Adds the above flag to the blur detection logic when the Enter key is pressed.


Here is the video after the fix. (The video before the fix can be found in the issue.)

https://github.com/user-attachments/assets/2c19dc80-aa25-44cb-93a6-e85ef183db5a

