### PR TITLE
Fixed bitwarden suggesting to create new password entries

### DIFF
--- a/packages/material-react-table/src/components/inputs/MRT_EditCellTextField.tsx
+++ b/packages/material-react-table/src/components/inputs/MRT_EditCellTextField.tsx
@@ -155,7 +155,7 @@ export const MRT_EditCellTextField = <TData extends MRT_RowData>({
         ...textFieldProps.SelectProps,
       }}
       inputProps={{
-        autoComplete: 'new-password', //disable autocomplete and autofill
+        autoComplete: 'off',
         ...textFieldProps.inputProps,
       }}
       onBlur={handleBlur}

--- a/packages/material-react-table/src/components/inputs/MRT_FilterTextField.tsx
+++ b/packages/material-react-table/src/components/inputs/MRT_FilterTextField.tsx
@@ -316,7 +316,7 @@ export const MRT_FilterTextField = <TData extends MRT_RowData>({
     ) : null,
     inputProps: {
       'aria-label': filterPlaceholder,
-      autoComplete: 'new-password', // disable autocomplete and autofill
+      autoComplete: 'off',
       disabled: !!filterChipLabel,
       sx: {
         textOverflow: 'ellipsis',

--- a/packages/material-react-table/src/components/inputs/MRT_GlobalFilterTextField.tsx
+++ b/packages/material-react-table/src/components/inputs/MRT_GlobalFilterTextField.tsx
@@ -94,7 +94,7 @@ export const MRT_GlobalFilterTextField = <TData extends MRT_RowData>({
     >
       <TextField
         inputProps={{
-          autoComplete: 'new-password', // disable autocomplete and autofill
+          autoComplete: 'off',
           ...textFieldProps.inputProps,
         }}
         onChange={handleChange}


### PR DESCRIPTION
Without this fix, text input filters show BitWarden (and presumably other browser auto-fill plugins) suggestions:
![image](https://github.com/user-attachments/assets/3faa310a-144f-47a3-9973-a260756f2e19)
