### PR TITLE
Fix missing deps in useEffect doing page index outbound check

### DIFF
--- a/packages/material-react-table/src/hooks/useMRT_Effects.ts
+++ b/packages/material-react-table/src/hooks/useMRT_Effects.ts
@@ -73,7 +73,7 @@ export const useMRT_Effects = <TData extends MRT_RowData>(
     if (firstVisibleRowIndex >= totalRowCount) {
       table.setPageIndex(Math.ceil(totalRowCount / pageSize) - 1);
     }
-  }, [totalRowCount]);
+  }, [totalRowCount, enablePagination, isLoading, showSkeletons]);
 
   //turn off sort when global filter is looking for ranked results
   const appliedSort = useRef<MRT_SortingState>(sorting);


### PR DESCRIPTION
PaginationState does not work when changing the example to pageIndex: >0.
While loading the totalRowCount is 0 resulting in setPageIndex(-1). The 'return' on first line should be hit.