### PR TITLE
MRT_RowActionMenu.tsx fix

### DIFF
--- a/packages/material-react-table/src/components/menus/MRT_RowActionMenu.tsx
+++ b/packages/material-react-table/src/components/menus/MRT_RowActionMenu.tsx
@@ -45,6 +45,7 @@ export const MRT_RowActionMenu = <TData extends MRT_RowData>({
     const editItem = parseFromValuesOrFunc(enableEditing, row) &&
       ['modal', 'row'].includes(editDisplayMode!) && (
         <MRT_ActionMenuItem
+          key={'edit'}
           icon={<EditIcon />}
           label={localization.edit}
           onClick={handleEdit}


### PR DESCRIPTION
Enabling editing for a row and adding renderRowActionMenuItems at the same time causes a warning:
`Warning: Each child in a list should have a unique "key" prop.`