### PR TITLE
Allow default behavior to be skipped for table navigation

### DIFF
--- a/packages/material-react-table/src/components/body/MRT_TableBodyCell.tsx
+++ b/packages/material-react-table/src/components/body/MRT_TableBodyCell.tsx
@@ -233,13 +233,13 @@ export const MRT_TableBodyCell = <TData extends MRT_RowData>({
   };
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLTableCellElement>) => {
+    tableCellProps?.onKeyDown?.(event);
     cellKeyboardShortcuts({
       cell,
       cellValue: cell.getValue<string>(),
       event,
       table,
     });
-    tableCellProps?.onKeyDown?.(event);
   };
 
   return (

--- a/packages/material-react-table/src/components/footer/MRT_TableFooterCell.tsx
+++ b/packages/material-react-table/src/components/footer/MRT_TableFooterCell.tsx
@@ -49,12 +49,12 @@ export const MRT_TableFooterCell = <TData extends MRT_RowData>({
   };
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLTableCellElement>) => {
+    tableCellProps?.onKeyDown?.(event);
     cellKeyboardShortcuts({
       event,
       cellValue: footer.column.columnDef.footer,
       table,
     });
-    tableCellProps?.onKeyDown?.(event);
   };
 
   return (

--- a/packages/material-react-table/src/components/head/MRT_TableHeadCell.tsx
+++ b/packages/material-react-table/src/components/head/MRT_TableHeadCell.tsx
@@ -150,14 +150,13 @@ export const MRT_TableHeadCell = <TData extends MRT_RowData>({
   };
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLTableCellElement>) => {
+    tableCellProps?.onKeyDown?.(event);
     cellKeyboardShortcuts({
       event,
       cellValue: header.column.columnDef.header,
       table,
       header,
     });
-
-    tableCellProps?.onKeyDown?.(event);
   };
 
   const HeaderElement =

--- a/packages/material-react-table/src/utils/cell.utils.ts
+++ b/packages/material-react-table/src/utils/cell.utils.ts
@@ -81,6 +81,7 @@ export const cellKeyboardShortcuts = <TData extends MRT_RowData = MRT_RowData>({
   table: MRT_TableInstance<TData>;
 }) => {
   if (!table.options.enableKeyboardShortcuts) return;
+  if (event.isPropagationStopped()) return;
   const currentCell = event.currentTarget;
 
   if (cellValue && isWinCtrlMacMeta(event) && event.key === 'c') {


### PR DESCRIPTION
User can call event.stopPropagation() to prevent MRT from processing default key accessibility behavior