### PR TITLE
Fix onCreatingRowSave return type to match documentation

### DIFF
--- a/packages/material-react-table/src/types.ts
+++ b/packages/material-react-table/src/types.ts
@@ -1196,7 +1196,7 @@ export interface MRT_TableOptions<TData extends MRT_RowData>
     row: MRT_Row<TData>;
     table: MRT_TableInstance<TData>;
     values: Record<LiteralUnion<string & DeepKeys<TData>>, any>;
-  }) => void;
+  }) => Promise<void> | void;
   onDensityChange?: OnChangeFn<MRT_DensityState>;
   onDraggingColumnChange?: OnChangeFn<MRT_Column<TData> | null>;
   onDraggingRowChange?: OnChangeFn<MRT_Row<TData> | null>;


### PR DESCRIPTION
[Acccording to the documentation](https://www.material-react-table.com/docs/api/table-options) `onCreatingRowSave` and `onEditingRowSave` should both accept a function with a return type of `Promise<void> | void` but in the typings the `onCreatingRowSave` accepts only `void`. This PR fixes this by adding the missing `Promise<void>` return type.