### PR TITLE
fix: clear sort action menu is disabled if no sorting is active

### DIFF
--- a/packages/material-react-table/src/components/menus/MRT_ColumnActionMenu.tsx
+++ b/packages/material-react-table/src/components/menus/MRT_ColumnActionMenu.tsx
@@ -150,6 +150,7 @@ export const MRT_ColumnActionMenu = <TData extends MRT_RowData>({
       ? [
           enableSortingRemoval !== false && (
             <MRT_ActionMenuItem
+              disabled={column.getIsSorted() === false}
               icon={<ClearAllIcon />}
               key={0}
               label={localization.clearSort}


### PR DESCRIPTION
Currently the clear sort action can be clicked when the column is not sorted. This is inconsistent to different items like Clear Filter and Unpin. Therefore a disabled check is added.

This fixed the issue https://github.com/KevinVandy/material-react-table/issues/1304