### PR TITLE
fix: overlapping input label when filter select is outline

### DIFF
--- a/packages/material-react-table/src/components/inputs/MRT_FilterTextField.tsx
+++ b/packages/material-react-table/src/components/inputs/MRT_FilterTextField.tsx
@@ -486,7 +486,9 @@ export const MRT_FilterTextField = <TData extends MRT_RowData>({
                       </Box>
                     )
                 : undefined,
-              ...commonTextFieldProps.SelectProps,
+            },
+            inputLabel: {
+              shrink: isSelectFilter || isMultiSelectFilter,
             },
           }}
           onChange={handleTextFieldChange}


### PR DESCRIPTION
As stated in the API Documentation of MUI https://mui.com/material-ui/api/select/#props the label should be shrunk when display empty is true.

I do not know why we need the display empty. If we remove it, the error also is removed. So you should consider what the use-case for displayEmpty really is.

Fixes: https://github.com/KevinVandy/material-react-table/issues/1142