### PR TITLE
docs: update custom column filter ui example

### DIFF
--- a/apps/material-react-table-docs/examples/custom-column-filtering-ui/sandbox/src/TS.tsx
+++ b/apps/material-react-table-docs/examples/custom-column-filtering-ui/sandbox/src/TS.tsx
@@ -57,14 +57,19 @@ const Example = () => {
       <MRT_TableContainer table={table} />
       <Paper>
         <Stack p="8px" gap="8px">
-          {table.getLeafHeaders().map((header) => (
-            <MRT_TableHeadCellFilterContainer
-              key={header.id}
-              header={header}
-              table={table}
-              in
-            />
-          ))}
+          {table
+            .getLeafHeaders()
+            .map(
+              (header) =>
+                header.column.getCanFilter() && (
+                  <MRT_TableHeadCellFilterContainer
+                    key={header.id}
+                    header={header}
+                    table={table}
+                    in
+                  />
+                ),
+            )}
         </Stack>
       </Paper>
     </Stack>


### PR DESCRIPTION
The example now includes a check if the column can be filtered. Only if possible the UI is rendered. 

Fixes https://github.com/KevinVandy/material-react-table/issues/1283