### PR TITLE
fix: reset column sizing button disabled when columnSize is 0

### DIFF
--- a/packages/material-react-table/src/components/menus/MRT_ColumnActionMenu.tsx
+++ b/packages/material-react-table/src/components/menus/MRT_ColumnActionMenu.tsx
@@ -277,7 +277,7 @@ export const MRT_ColumnActionMenu = <TData extends MRT_RowData>({
     ...(enableColumnResizing && column.getCanResize()
       ? [
           <MRT_ActionMenuItem
-            disabled={!columnSizing[column.id]}
+            disabled={columnSizing[column.id] === undefined}
             icon={<RestartAltIcon />}
             key={10}
             label={localization.resetColumnSize}


### PR DESCRIPTION
When dragging the column to the minimum possible, the columnSize is 0. With the previous implementation this was resulting in true which disabled the ation menu item.

In my opinion the action menu item should only be disabled if the column does not occur in the column sizing state resulting in an explicit check for undefined.

Fixes: https://github.com/KevinVandy/material-react-table/issues/1256