### PR TITLE
fix: editInputRefs assignment for select textfields

### DIFF
--- a/packages/material-react-table/src/components/inputs/MRT_EditCellTextField.tsx
+++ b/packages/material-react-table/src/components/inputs/MRT_EditCellTextField.tsx
@@ -110,7 +110,9 @@ export const MRT_EditCellTextField = <TData extends MRT_RowData>({
       fullWidth
       inputRef={(inputRef) => {
         if (inputRef) {
-          editInputRefs.current![column.id] = inputRef;
+          editInputRefs.current![column.id] = isSelectEdit
+            ? inputRef.node
+            : inputRef;
           if (textFieldProps.inputRef) {
             textFieldProps.inputRef = inputRef;
           }


### PR DESCRIPTION
When the edit cell textfield is configured as a select the ref returns an object with a node property that holds the input element as value.

Therefore the assignment is adjusted with a condition to get the input element correct.

Fixes: https://github.com/KevinVandy/material-react-table/issues/1245