### PR TITLE
fix: total row count for selection went up when grouping

### DIFF
--- a/packages/material-react-table/src/components/toolbar/MRT_ToolbarAlertBanner.tsx
+++ b/packages/material-react-table/src/components/toolbar/MRT_ToolbarAlertBanner.tsx
@@ -24,7 +24,7 @@ export const MRT_ToolbarAlertBanner = <TData extends MRT_RowData>({
 }: MRT_ToolbarAlertBannerProps<TData>) => {
   const {
     getFilteredSelectedRowModel,
-    getPrePaginationRowModel,
+    getCoreRowModel,
     getState,
     options: {
       enableRowSelection,
@@ -52,7 +52,7 @@ export const MRT_ToolbarAlertBanner = <TData extends MRT_RowData>({
     table,
   });
 
-  const totalRowCount = rowCount ?? getPrePaginationRowModel().flatRows.length;
+  const totalRowCount = rowCount ?? getCoreRowModel().rows.length;
 
   const selectedRowCount = useMemo(
     () =>


### PR DESCRIPTION
Beforehand the total row count went up when grouping.

This is fixed by using the core row modal as none transformation has happend. From my understanding this will always give the amount of possible rows to select as this is the max amount of rows given to the table.

Fixes: https://github.com/KevinVandy/material-react-table/issues/1227