### PR TITLE
Feature: adding top content option

### DIFF
--- a/packages/material-react-table/src/components/head/MRT_TableHead.tsx
+++ b/packages/material-react-table/src/components/head/MRT_TableHead.tsx
@@ -25,6 +25,7 @@ export const MRT_TableHead = <TData extends MRT_RowData>({
     options: {
       enableStickyHeader,
       enableTopContent,
+      enableTopToolbar,
       layoutMode,
       muiTableHeadProps,
       positionToolbarAlertBanner,
@@ -57,7 +58,7 @@ export const MRT_TableHead = <TData extends MRT_RowData>({
         top:
           stickyHeader && layoutMode?.startsWith('grid')
             ? 0
-            : enableStickyHeader && enableTopContent
+            : enableStickyHeader && enableTopContent && enableTopToolbar
               ? getCommonToolbarStyles({ table, theme }).minHeight
               : undefined,
         zIndex: stickyHeader ? 2 : undefined,

--- a/packages/material-react-table/src/components/head/MRT_TableHead.tsx
+++ b/packages/material-react-table/src/components/head/MRT_TableHead.tsx
@@ -7,6 +7,7 @@ import {
 } from '../../types';
 import { parseFromValuesOrFunc } from '../../utils/utils';
 import { MRT_ToolbarAlertBanner } from '../toolbar/MRT_ToolbarAlertBanner';
+import { getCommonToolbarStyles } from '../../utils/style.utils';
 
 export interface MRT_TableHeadProps<TData extends MRT_RowData>
   extends TableHeadProps {
@@ -23,6 +24,7 @@ export const MRT_TableHead = <TData extends MRT_RowData>({
     getState,
     options: {
       enableStickyHeader,
+      enableTopContent,
       layoutMode,
       muiTableHeadProps,
       positionToolbarAlertBanner,
@@ -52,7 +54,12 @@ export const MRT_TableHead = <TData extends MRT_RowData>({
         display: layoutMode?.startsWith('grid') ? 'grid' : undefined,
         opacity: 0.97,
         position: stickyHeader ? 'sticky' : 'relative',
-        top: stickyHeader && layoutMode?.startsWith('grid') ? 0 : undefined,
+        top:
+          stickyHeader && layoutMode?.startsWith('grid')
+            ? 0
+            : enableStickyHeader && enableTopContent
+              ? getCommonToolbarStyles({ table, theme }).minHeight
+              : undefined,
         zIndex: stickyHeader ? 2 : undefined,
         ...(parseFromValuesOrFunc(tableHeadProps?.sx, theme) as any),
       })}

--- a/packages/material-react-table/src/components/table/MRT_TableContainer.tsx
+++ b/packages/material-react-table/src/components/table/MRT_TableContainer.tsx
@@ -8,6 +8,7 @@ import { type MRT_RowData, type MRT_TableInstance } from '../../types';
 import { parseFromValuesOrFunc } from '../../utils/utils';
 import { MRT_CellActionMenu } from '../menus/MRT_CellActionMenu';
 import { MRT_EditRowModal } from '../modals/MRT_EditRowModal';
+import { MRT_TopContent } from '../toolbar/MRT_TopContent';
 
 const useIsomorphicLayoutEffect =
   typeof window !== 'undefined' ? useLayoutEffect : useEffect;
@@ -29,6 +30,7 @@ export const MRT_TableContainer = <TData extends MRT_RowData>({
       enableCellActions,
       enableStickyHeader,
       muiTableContainerProps,
+      enableTopContent,
     },
     refs: { bottomToolbarRef, tableContainerRef, topToolbarRef },
   } = table;
@@ -101,6 +103,7 @@ export const MRT_TableContainer = <TData extends MRT_RowData>({
       })}
     >
       {loading ? <MRT_TableLoadingOverlay table={table} /> : null}
+      {enableTopContent ? <MRT_TopContent table={table} /> : null}
       <MRT_Table table={table} />
       {(createModalOpen || editModalOpen) && (
         <MRT_EditRowModal open table={table} />

--- a/packages/material-react-table/src/components/table/MRT_TablePaper.tsx
+++ b/packages/material-react-table/src/components/table/MRT_TablePaper.tsx
@@ -19,6 +19,7 @@ export const MRT_TablePaper = <TData extends MRT_RowData>({
     getState,
     options: {
       enableBottomToolbar,
+      enableTopContent,
       enableTopToolbar,
       mrtTheme: { baseBackgroundColor },
       muiTablePaperProps,
@@ -76,6 +77,7 @@ export const MRT_TablePaper = <TData extends MRT_RowData>({
       })}
     >
       {enableTopToolbar &&
+        !enableTopContent &&
         (parseFromValuesOrFunc(renderTopToolbar, { table }) ?? (
           <MRT_TopToolbar table={table} />
         ))}

--- a/packages/material-react-table/src/components/toolbar/MRT_TopContent.tsx
+++ b/packages/material-react-table/src/components/toolbar/MRT_TopContent.tsx
@@ -1,0 +1,29 @@
+import Box from '@mui/material/Box';
+import { parseFromValuesOrFunc } from '../../utils/utils';
+import { MRT_TopToolbar } from './MRT_TopToolbar';
+import type { MRT_RowData, MRT_TableInstance } from '../../types';
+
+export interface MRT_TopContentProps<TData extends MRT_RowData> {
+  table: MRT_TableInstance<TData>;
+}
+
+export const MRT_TopContent = <TData extends MRT_RowData>({
+  table,
+}: MRT_TopContentProps<TData>) => {
+  const {
+    options: { renderTopContent },
+  } = table;
+  return (
+    <>
+      <Box
+        sx={() => ({
+          position: 'sticky',
+          insetInlineStart: 0,
+        })}
+      >
+        {parseFromValuesOrFunc(renderTopContent, { table })}
+      </Box>
+      <MRT_TopToolbar table={table} />
+    </>
+  );
+};

--- a/packages/material-react-table/src/components/toolbar/MRT_TopContent.tsx
+++ b/packages/material-react-table/src/components/toolbar/MRT_TopContent.tsx
@@ -11,7 +11,7 @@ export const MRT_TopContent = <TData extends MRT_RowData>({
   table,
 }: MRT_TopContentProps<TData>) => {
   const {
-    options: { renderTopContent },
+    options: { renderTopContent, enableTopToolbar },
   } = table;
   return (
     <>
@@ -23,7 +23,7 @@ export const MRT_TopContent = <TData extends MRT_RowData>({
       >
         {parseFromValuesOrFunc(renderTopContent, { table })}
       </Box>
-      <MRT_TopToolbar table={table} />
+      {enableTopToolbar && <MRT_TopToolbar table={table} />}
     </>
   );
 };

--- a/packages/material-react-table/src/components/toolbar/MRT_TopToolbar.tsx
+++ b/packages/material-react-table/src/components/toolbar/MRT_TopToolbar.tsx
@@ -22,6 +22,7 @@ export const MRT_TopToolbar = <TData extends MRT_RowData>({
     options: {
       enableGlobalFilter,
       enablePagination,
+      enableTopContent,
       enableToolbarInternalActions,
       muiTopToolbarProps,
       positionGlobalFilter,
@@ -66,9 +67,11 @@ export const MRT_TopToolbar = <TData extends MRT_RowData>({
       }}
       sx={(theme) => ({
         ...getCommonToolbarStyles({ table, theme }),
-        position: isFullScreen ? 'sticky' : 'relative',
-        top: isFullScreen ? '0' : undefined,
+        position: isFullScreen || enableTopContent ? 'sticky' : 'relative',
+        top: isFullScreen || enableTopContent ? '0' : undefined,
         ...(parseFromValuesOrFunc(toolbarProps?.sx, theme) as any),
+        insetInlineStart: enableTopContent ? 0 : undefined,
+        zIndex: enableTopContent ? 3 : undefined,
       })}
     >
       {positionToolbarAlertBanner === 'top' && (

--- a/packages/material-react-table/src/types.ts
+++ b/packages/material-react-table/src/types.ts
@@ -883,6 +883,7 @@ export interface MRT_TableOptions<TData extends MRT_RowData>
   enableTableFooter?: boolean;
   enableTableHead?: boolean;
   enableToolbarInternalActions?: boolean;
+  enableTopContent?: boolean;
   enableTopToolbar?: boolean;
   expandRowsFn?: (dataRow: TData) => TData[];
   getRowId?: (
@@ -1258,6 +1259,9 @@ export interface MRT_TableOptions<TData extends MRT_RowData>
   renderToolbarInternalActions?: (props: {
     table: MRT_TableInstance<TData>;
   }) => ReactNode;
+  renderTopContent?:
+    | ((props: { table: MRT_TableInstance<TData> }) => ReactNode)
+    | ReactNode;
   renderTopToolbar?:
     | ((props: { table: MRT_TableInstance<TData> }) => ReactNode)
     | ReactNode;

--- a/packages/material-react-table/stories/styling/TopContent.stories.tsx
+++ b/packages/material-react-table/stories/styling/TopContent.stories.tsx
@@ -1,0 +1,99 @@
+import { type MRT_ColumnDef, MaterialReactTable } from '../../src';
+import { faker } from '@faker-js/faker';
+import { type Meta } from '@storybook/react';
+import Paper from '@mui/material/Paper';
+
+const meta: Meta = {
+  parameters: {
+    status: {
+      type: 'stable',
+    },
+  },
+  title: 'Styling/Top Content Examples',
+};
+
+export default meta;
+
+const columns: MRT_ColumnDef<(typeof data)[0]>[] = [
+  {
+    accessorKey: 'firstName',
+    header: 'First Name',
+  },
+  {
+    accessorKey: 'lastName',
+    header: 'Last Name',
+  },
+  {
+    accessorKey: 'address',
+    header: 'Address',
+  },
+  {
+    accessorKey: 'state',
+    header: 'State',
+  },
+  {
+    accessorKey: 'phoneNumber',
+    header: 'Phone Number',
+  },
+];
+
+const data = [...Array(88)].map(() => ({
+  address: faker.location.streetAddress(),
+  firstName: faker.person.firstName(),
+  lastName: faker.person.lastName(),
+  phoneNumber: faker.phone.number(),
+  state: faker.location.state(),
+}));
+
+export const TopContentWithStaticHeader = () => (
+  <MaterialReactTable
+    columns={columns}
+    data={data}
+    initialState={{ pagination: { pageIndex: 0, pageSize: 25 } }}
+    enableTopContent={true}
+    renderTopContent={({ table }) => (
+      <Paper elevation={3} sx={{ padding: '0.5rem', margin: '0.5rem' }}>
+        <h2 style={{ margin: '2rem', textAlign: 'center' }}>
+          Total rows: {table.getRowCount()}
+        </h2>
+      </Paper>
+    )}
+  />
+);
+
+export const TopContentWithStickyHeader = () => (
+  <MaterialReactTable
+    columns={columns}
+    data={data}
+    enableStickyHeader
+    initialState={{ pagination: { pageIndex: 0, pageSize: 25 } }}
+    enableTopContent={true}
+    renderTopContent={({ table }) => (
+      <Paper elevation={3} sx={{ padding: '0.5rem', margin: '0.5rem' }}>
+        <h2 style={{ margin: '2rem', textAlign: 'center' }}>
+          Total rows: {table.getRowCount()}
+        </h2>
+      </Paper>
+    )}
+  />
+);
+
+export const TopContentWithStickyHeaderShorterTable = () => (
+  <MaterialReactTable
+    columns={columns}
+    data={data}
+    enableColumnPinning
+    enableRowSelection
+    enableStickyHeader
+    initialState={{ pagination: { pageIndex: 0, pageSize: 25 } }}
+    muiTableContainerProps={{ sx: { maxHeight: 400 } }}
+    enableTopContent={true}
+    renderTopContent={({ table }) => (
+      <Paper elevation={3} sx={{ padding: '0.5rem', margin: '0.5rem' }}>
+        <h2 style={{ margin: '2rem', textAlign: 'center' }}>
+          Total rows: {table.getRowCount()}
+        </h2>
+      </Paper>
+    )}
+  />
+);

--- a/packages/material-react-table/stories/styling/TopContent.stories.tsx
+++ b/packages/material-react-table/stories/styling/TopContent.stories.tsx
@@ -45,7 +45,7 @@ const data = [...Array(88)].map(() => ({
   state: faker.location.state(),
 }));
 
-export const TopContentWithStaticHeader = () => (
+export const TopContentWithStaticHeaderDefault = () => (
   <MaterialReactTable
     columns={columns}
     data={data}
@@ -87,6 +87,25 @@ export const TopContentWithStickyHeaderShorterTable = () => (
     enableStickyHeader
     initialState={{ pagination: { pageIndex: 0, pageSize: 25 } }}
     muiTableContainerProps={{ sx: { maxHeight: 400 } }}
+    enableTopContent={true}
+    renderTopContent={({ table }) => (
+      <Paper elevation={3} sx={{ padding: '0.5rem', margin: '0.5rem' }}>
+        <h2 style={{ margin: '2rem', textAlign: 'center' }}>
+          Total rows: {table.getRowCount()}
+        </h2>
+      </Paper>
+    )}
+  />
+);
+
+export const TopContentWithHiddenTopToolbar = () => (
+  <MaterialReactTable
+    columns={columns}
+    data={data}
+    initialState={{ pagination: { pageIndex: 0, pageSize: 25 } }}
+    muiTableContainerProps={{ sx: { maxHeight: 400 } }}
+    enableStickyHeader
+    enableTopToolbar={false}
     enableTopContent={true}
     renderTopContent={({ table }) => (
       <Paper elevation={3} sx={{ padding: '0.5rem', margin: '0.5rem' }}>


### PR DESCRIPTION
This PR adds the option to include arbitrary content at the top of the scroll container.

The main use case is pages with long tables and additional content above them, such as a summary. Currently the only way to place the summary above is to limit the height of the table based on the viewport and the content, which can cause various UX issues (e.g double scrollbars from the page and table; tiny tables on short screens; etc.)

This solution is to allow including additional JSX inside `MRT_TableContainer`, and setting its wrapper to be sticky in the horizontal axis so it will not scroll with the table. 

The only slight complication is that `MRT_TopToolbar` needs to be added separately inside the sticky wrapper instead of `MRT_TablePaper` (this also means adjusting the sticky header's `top` property).