### PR TITLE
Bug: Allow override slot properties of input in MRT_FilterTextField

### DIFF
--- a/packages/material-react-table/src/components/inputs/MRT_FilterTextField.tsx
+++ b/packages/material-react-table/src/components/inputs/MRT_FilterTextField.tsx
@@ -343,8 +343,8 @@ export const MRT_FilterTextField = <TData extends MRT_RowData>({
         ...textFieldProps.slotProps?.formHelperText,
       },
       input: endAdornment //hack because mui looks for presence of endAdornment key instead of undefined
-        ? { endAdornment, startAdornment }
-        : { startAdornment },
+        ? {endAdornment, startAdornment, ...textFieldProps.slotProps?.input}
+        : {startAdornment, ...textFieldProps.slotProps?.input},
       htmlInput: {
         'aria-label': filterPlaceholder,
         autoComplete: 'off',


### PR DESCRIPTION
Allow override to slot properties of input in MRT_FilterTextField