### PR TITLE
fix: use single call for hiding/showing all columns within show/hide menu

### DIFF
--- a/packages/material-react-table/src/components/menus/MRT_ShowHideColumnsMenu.tsx
+++ b/packages/material-react-table/src/components/menus/MRT_ShowHideColumnsMenu.tsx
@@ -8,6 +8,7 @@ import {
   type MRT_Column,
   type MRT_RowData,
   type MRT_TableInstance,
+  type MRT_VisibilityState
 } from '../../types';
 import { getDefaultColumnOrderIds } from '../../utils/displayColumn.utils';
 
@@ -47,9 +48,15 @@ export const MRT_ShowHideColumnsMenu = <TData extends MRT_RowData>({
   const { columnOrder, columnPinning, density } = getState();
 
   const handleToggleAllColumns = (value?: boolean) => {
-    getAllLeafColumns()
-      .filter((col) => col.columnDef.enableHiding !== false)
-      .forEach((col) => col.toggleVisibility(value));
+    const updates =
+      getAllLeafColumns()
+        .filter((column) => column.columnDef.enableHiding !== false)
+        .reduce((acc, column) => {
+          acc[column.id] = value ?? !column.getIsVisible()
+          return acc;
+        }, {} as MRT_VisibilityState);
+
+    table.setColumnVisibility((old) => ({ ...old, ...updates }));
   };
 
   const allColumns = useMemo(() => {


### PR DESCRIPTION
Reworked to toggle visibility with single call while preserving the behavior of the previous implementation.  With this change the `onColumnVisibilityChange` callback will only be called once. 
Fixes: #1126