### PR TITLE
Update French translation to use the correct context

### DIFF
--- a/packages/material-react-table/src/locales/fr.ts
+++ b/packages/material-react-table/src/locales/fr.ts
@@ -58,7 +58,7 @@ export const MRT_Localization_FR: MRT_Localization = {
   max: 'Max',
   min: 'Min',
   move: 'Déplacer',
-  noRecordsToDisplay: 'Aucun enregistrement à afficher',
+  noRecordsToDisplay: 'Aucune entrée à afficher',
   noResultsFound: 'Aucun résultat trouvé',
   of: 'de',
   or: 'ou',


### PR DESCRIPTION
Hi, I have made a small change to the French translation.

The literal translation of `noRecordsToDisplay` is correct, but it is out of context.
`Enregistrement` is used in the context of movies and music. I have replaced it with `entrée`, which is more appropriate.

I think there are more changes that can be made to the French language. I will open a new PR if I find anything else, or update this one if it is not merged.