### PR TITLE
1426: using relative width instead of fixed width as a fallback for w…

### DIFF
--- a/packages/material-react-table/src/components/body/MRT_TableBody.tsx
+++ b/packages/material-react-table/src/components/body/MRT_TableBody.tsx
@@ -135,8 +135,8 @@ export const MRT_TableBody = <TData extends MRT_RowData>({
                       color: 'text.secondary',
                       fontStyle: 'italic',
                       maxWidth: `min(100vw, ${
-                        tablePaperRef.current?.clientWidth ?? 360
-                      }px)`,
+                        tablePaperRef.current?.clientWidth ? tablePaperRef.current?.clientWidth + "px" : "100%"
+                      })`,
                       py: '2rem',
                       textAlign: 'center',
                       width: '100%',


### PR DESCRIPTION
Related to this issue - https://github.com/KevinVandy/material-react-table/issues/1426

This solution is far from ideal as described in the issue.
However, I think it is still better than what is currently there.

Leaving it to you for consideration.