### PR TITLE
fix: rows and cells don't have a stable keys if the row is move to another index

### DIFF
--- a/packages/material-react-table/src/components/body/MRT_TableBody.tsx
+++ b/packages/material-react-table/src/components/body/MRT_TableBody.tsx
@@ -175,11 +175,10 @@ export const MRT_TableBody = <TData extends MRT_RowData>({
                     ? (rowOrVirtualRow as VirtualItem)
                     : undefined,
                 };
-                const key = `${row.id}-${row.index}`;
                 return memoMode === 'rows' ? (
-                  <Memo_MRT_TableBodyRow key={key} {...props} />
+                  <Memo_MRT_TableBodyRow key={row.id} {...props} />
                 ) : (
-                  <MRT_TableBodyRow key={key} {...props} />
+                  <MRT_TableBodyRow key={row.id} {...props} />
                 );
               })}
             </>

--- a/packages/material-react-table/src/components/body/MRT_TableBodyRow.tsx
+++ b/packages/material-react-table/src/components/body/MRT_TableBodyRow.tsx
@@ -248,7 +248,6 @@ export const MRT_TableBodyRow = <TData extends MRT_RowData>({
               staticRowIndex,
               table,
             };
-            const key = `${cell.id}-${staticRowIndex}`;
             return cell ? (
               memoMode === 'cells' &&
               cell.column.columnDef.columnDefType === 'data' &&
@@ -256,9 +255,9 @@ export const MRT_TableBodyRow = <TData extends MRT_RowData>({
               !draggingRow &&
               editingCell?.id !== cell.id &&
               editingRow?.id !== row.id ? (
-                <Memo_MRT_TableBodyCell key={key} {...props} />
+                <Memo_MRT_TableBodyCell key={cell.id} {...props} />
               ) : (
-                <MRT_TableBodyCell key={key} {...props} />
+                <MRT_TableBodyCell key={cell.id} {...props} />
               )
             ) : null;
           },

--- a/packages/material-react-table/src/hooks/useMRT_TableInstance.ts
+++ b/packages/material-react-table/src/hooks/useMRT_TableInstance.ts
@@ -229,9 +229,11 @@ export const useMRT_TableInstance = <TData extends MRT_RowData>(
             ...Array(
               Math.min(statefulTableOptions.state.pagination.pageSize, 20),
             ).fill(null),
-          ].map(() =>
+          ].map((_, index) =>
             Object.assign(
-              {},
+              {
+                'mrt-skeleton-id': `skeleton-${index}`,
+              },
               ...getAllLeafColumnDefs(statefulTableOptions.columns).map(
                 (col) => ({
                   [getColumnId(col)]: null,
@@ -246,6 +248,15 @@ export const useMRT_TableInstance = <TData extends MRT_RowData>(
       statefulTableOptions.state.showSkeletons,
     ],
   );
+
+  statefulTableOptions.getRowId = useMemo(() => {
+    const getRowId = statefulTableOptions.getRowId;
+    return (originalRow, index, parentRow) => {
+      if ('mrt-skeleton-id' in originalRow)
+        return originalRow['mrt-skeleton-id'];
+      return getRowId?.(originalRow, index, parentRow);
+    };
+  }, [statefulTableOptions.getRowId]);
 
   //@ts-expect-error
   const table = useReactTable({


### PR DESCRIPTION
This PR  fixes #1459

This code also include a another way of fixing https://github.com/KevinVandy/material-react-table/issues/808

Note: It might cause some issues for users who fail to provide a getRowId function that returns unique IDs.