### PR TITLE
fix: wrap IconButton in a span for consistent rendering in MRT_ToggleGlobalFilterButton

### DIFF
--- a/packages/material-react-table/src/components/buttons/MRT_ToggleGlobalFilterButton.tsx
+++ b/packages/material-react-table/src/components/buttons/MRT_ToggleGlobalFilterButton.tsx
@@ -30,15 +30,17 @@ export const MRT_ToggleGlobalFilterButton = <TData extends MRT_RowData>({
 
   return (
     <Tooltip title={rest?.title ?? localization.showHideSearch}>
-      <IconButton
-        aria-label={rest?.title ?? localization.showHideSearch}
-        disabled={!!globalFilter && showGlobalFilter}
-        onClick={handleToggleSearch}
-        {...rest}
-        title={undefined}
-      >
-        {showGlobalFilter ? <SearchOffIcon /> : <SearchIcon />}
-      </IconButton>
+      <span>
+        <IconButton
+          aria-label={rest?.title ?? localization.showHideSearch}
+          disabled={!!globalFilter && showGlobalFilter}
+          onClick={handleToggleSearch}
+          {...rest}
+          title={undefined}
+        >
+          {showGlobalFilter ? <SearchOffIcon /> : <SearchIcon />}
+        </IconButton>
+      </span>
     </Tooltip>
   );
 };


### PR DESCRIPTION
This pull request makes a small but important accessibility improvement to the `MRT_ToggleGlobalFilterButton` component. The change wraps the `IconButton` in a `<span>`, which ensures that the button remains focusable and accessible when disabled, as required by accessibility best practices.

- Accessibility improvement:
  * Wrapped the `IconButton` in a `<span>` within the `MRT_ToggleGlobalFilterButton` component to maintain accessibility when the button is disabled. [[1]](diffhunk://#diff-901f89533e09beaa2eba5d780d51ad79d3fec15844493ed3c8a0351a05fe75f0R33) [[2]](diffhunk://#diff-901f89533e09beaa2eba5d780d51ad79d3fec15844493ed3c8a0351a05fe75f0R43)