### PR TITLE
fix: showProgressBars ignores isLoading state - progress bars always visible when showProgressBars: true

### DIFF
--- a/packages/material-react-table/src/components/toolbar/MRT_LinearProgressBar.tsx
+++ b/packages/material-react-table/src/components/toolbar/MRT_LinearProgressBar.tsx
@@ -20,7 +20,7 @@ export const MRT_LinearProgressBar = <TData extends MRT_RowData>({
     getState,
     options: { muiLinearProgressProps },
   } = table;
-  const { isSaving, showProgressBars } = getState();
+  const { isLoading, isSaving, showProgressBars } = getState();
 
   const linearProgressProps = {
     ...parseFromValuesOrFunc(muiLinearProgressProps, {
@@ -32,7 +32,7 @@ export const MRT_LinearProgressBar = <TData extends MRT_RowData>({
 
   return (
     <Collapse
-      in={showProgressBars !== false && (showProgressBars || isSaving)}
+      in={showProgressBars !== false && (isLoading || isSaving)}
       mountOnEnter
       sx={{
         bottom: isTopToolbar ? 0 : undefined,


### PR DESCRIPTION
This PR fixes #1471 

TLDR: added a small check for `isLoading` in `MRT_LinearProgressBar`