### PR TITLE
fix: update peer dependencies to support newer versions of MUI packages

### DIFF
--- a/packages/material-react-table/package.json
+++ b/packages/material-react-table/package.json
@@ -106,9 +106,9 @@
   "peerDependencies": {
     "@emotion/react": ">=11.13",
     "@emotion/styled": ">=11.13",
-    "@mui/icons-material": ">=6",
-    "@mui/material": ">=6",
-    "@mui/x-date-pickers": ">=7.15",
+    "@mui/icons-material": ">=6 || ^7.0.0",
+    "@mui/material": ">=6 || ^7.0.0",
+    "@mui/x-date-pickers": ">=7.15 || ^7.0.0",
     "react": ">=18.0",
     "react-dom": ">=18.0"
   },


### PR DESCRIPTION
**Change**: Expand peerDependencies in [package.json](vscode-file://vscode-app/Users/vostrypet/Downloads/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to support MUI v7 alongside v6 (@mui/material, @mui/icons-material, @mui/x-date-pickers now >=6 || ^7.0.0).

**Reason**: Allow projects on MUI v7 to use material-react-table without forks or local overrides.

**Real-world verification**: We are using material-react-table with MUI v7 in our project, where we overridden the peer ranges in [package.json](vscode-file://vscode-app/Users/vostrypet/Downloads/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to >=6 || ^7.0.0. Everything works smoothly—components, styling, and interactions are fully compatible.

**Compatibility**: MUI v6 remains supported; this is a semver range extension only.

**Impact**: No API or build changes; safe peer dependency update.