### PR TITLE
fix: multi-select filter

### DIFF
--- a/packages/material-react-table/src/components/inputs/MRT_FilterTextField.tsx
+++ b/packages/material-react-table/src/components/inputs/MRT_FilterTextField.tsx
@@ -168,6 +168,8 @@ export const MRT_FilterTextField = <TData extends MRT_RowData>({
             newFilterValues[rangeFilterIndex as number] = newValue ?? undefined;
             return newFilterValues;
           });
+        } else if (isMultiSelectFilter && Array.isArray(newValue) && newValue.length === 0) {
+          column.setFilterValue(undefined);
         } else {
           column.setFilterValue(newValue ?? undefined);
         }
@@ -209,7 +211,7 @@ export const MRT_FilterTextField = <TData extends MRT_RowData>({
   const handleClear = () => {
     if (isMultiSelectFilter) {
       setFilterValue([]);
-      column.setFilterValue([]);
+      column.setFilterValue(undefined);
     } else if (isRangeFilter) {
       setFilterValue('');
       column.setFilterValue((old: [string | undefined, string | undefined]) => {


### PR DESCRIPTION
When using a custom `filterFn` on a column in `MaterialReactTable`, the column shows the “filtered” icon even when the filter has been cleared.
This suggests that the table treats an empty filter value as an active filter.

Expected Behaviour
When the filter is cleared (e.g., multiselect returns an empty array), the column should not display the filtered icon, and the tooltip should not appear.

Actual Behaviour
`filterValue` becomes [] when the filter is cleared.

The table interprets [] as a truthy/active filter.

The filtered icon and tooltip remain visible even though no filter is applied.

Steps to Reproduce
- Create a column using a custom filterFn.
- Use a multiselect filter UI for that column.
- Clear the filter so that filterValue becomes an empty array.
- Observe that the column still shows the filtered icon and tooltip.
