### PR TITLE
fix: french translation for "Show All" text

### DIFF
--- a/packages/material-react-table/src/locales/fr.ts
+++ b/packages/material-react-table/src/locales/fr.ts
@@ -76,7 +76,7 @@ export const MRT_Localization_FR: MRT_Localization = {
   selectedCountOfRowCountRowsSelected:
     '{selectedCount} sur {rowCount} ligne(s)',
   select: 'Sélectionner',
-  showAll: 'Afficher tous',
+  showAll: 'Afficher tout',
   showAllColumns: 'Afficher toutes les colonnes',
   showHideColumns: 'Afficher/Masquer les colonnes',
   showHideFilters: 'Afficher/Masquer les filtres',


### PR DESCRIPTION
Replaced "Afficher tous" with "Afficher tout".

It aligns with the existing wording “Cacher tout”, ensuring grammatical consistency in the interface.