### PR TITLE
fix: #1481 disable Hide All button when all hideable columns are hidden

### DIFF
--- a/packages/material-react-table/src/components/menus/MRT_ShowHideColumnsMenu.tsx
+++ b/packages/material-react-table/src/components/menus/MRT_ShowHideColumnsMenu.tsx
@@ -32,7 +32,6 @@ export const MRT_ShowHideColumnsMenu = <TData extends MRT_RowData>({
     getCenterLeafColumns,
     getIsAllColumnsVisible,
     getIsSomeColumnsPinned,
-    getIsSomeColumnsVisible,
     getLeftLeafColumns,
     getRightLeafColumns,
     getState,
@@ -101,6 +100,11 @@ export const MRT_ShowHideColumnsMenu = <TData extends MRT_RowData>({
     null,
   );
 
+  const areAllHideableColumnsHidden = () =>
+    getAllLeafColumns()
+      .filter((column) => column.columnDef.enableHiding !== false)
+      .every((column) => !column.getIsVisible());
+
   return (
     <Menu
       MenuListProps={{
@@ -125,7 +129,7 @@ export const MRT_ShowHideColumnsMenu = <TData extends MRT_RowData>({
       >
         {enableHiding && (
           <Button
-            disabled={!getIsSomeColumnsVisible()}
+            disabled={areAllHideableColumnsHidden()}
             onClick={() => handleToggleAllColumns(false)}
           >
             {localization.hideAll}

--- a/packages/material-react-table/src/components/menus/MRT_ShowHideColumnsMenu.tsx
+++ b/packages/material-react-table/src/components/menus/MRT_ShowHideColumnsMenu.tsx
@@ -101,9 +101,10 @@ export const MRT_ShowHideColumnsMenu = <TData extends MRT_RowData>({
   );
 
   const areAllHideableColumnsHidden = () =>
-    getAllLeafColumns()
-      .filter((column) => column.columnDef.enableHiding !== false)
-      .every((column) => !column.getIsVisible());
+    getAllLeafColumns().every(
+      (column) =>
+        column.columnDef.enableHiding === false || !column.getIsVisible(),
+    );
 
   return (
     <Menu


### PR DESCRIPTION
Earlier, the code relied on `getIsSomeColumnsVisible`, which returned `true` as it included the columns which cannot be hidden.

This commit introduces a new function `areAllHideableColumnsHidden` which only considers the columns that are hideable.

Fixes: #1481 