### PR TITLE
fix: #1509 column visibility toggle disabled state for header groups

### DIFF
--- a/packages/material-react-table/src/components/menus/MRT_ShowHideColumnsMenuItems.tsx
+++ b/packages/material-react-table/src/components/menus/MRT_ShowHideColumnsMenuItems.tsx
@@ -109,6 +109,17 @@ export const MRT_ShowHideColumnsMenuItems = <TData extends MRT_RowData>({
     return null;
   }
 
+  const isColumnVisibilityToggleDisabled = () => {
+    const cols = column.columns;
+
+    const isNonHidable = (c: MRT_Column<TData>) =>
+      c.columnDef.enableHiding === false;
+
+    if (!cols?.length || !cols.some(isNonHidable)) return !column.getCanHide();
+
+    return cols.every((c) => isNonHidable(c) || !c.getIsVisible());
+  };
+
   return (
     <>
       <MenuItem
@@ -176,7 +187,7 @@ export const MRT_ShowHideColumnsMenuItems = <TData extends MRT_RowData>({
                   <Switch />
                 </Tooltip>
               }
-              disabled={!column.getCanHide()}
+              disabled={isColumnVisibilityToggleDisabled()}
               label={columnDef.header}
               onChange={() => handleToggleColumnHidden(column)}
             />


### PR DESCRIPTION
Previously, the disabled state relied solely on `!column.getCanHide()` from the TanStack Table API. While this works for leaf columns, it does not correctly represent the disabled state for header groups with child columns that have `enabledHiding: false`.

This change adds a dedicated function to compute the disabled state for grouped columns by considering the visibility and `enableHiding` configuration of their child columns.

Fixes: #1509 