### PR TITLE
fix: group row ID leaks into rowSelection when selecting grouped rows

### DIFF
--- a/packages/material-react-table/src/components/inputs/MRT_SelectCheckbox.tsx
+++ b/packages/material-react-table/src/components/inputs/MRT_SelectCheckbox.tsx
@@ -43,10 +43,15 @@ export const MRT_SelectCheckbox = <TData extends MRT_RowData>({
 
   const selectAll = !row;
 
+  const getLeafRows = () => (
+    selectAllMode === 'page'
+    ? table.getPaginationRowModel().flatRows
+    : table.getPrePaginationRowModel().flatRows
+  ).filter((r) => !r.getIsGrouped());
+
+  // Fix: getIsAllPageRowsSelected() / getIsAllRowsSelected() include group rows
   const allRowsSelected = selectAll
-    ? selectAllMode === 'page'
-      ? table.getIsAllPageRowsSelected()
-      : table.getIsAllRowsSelected()
+    ? getLeafRows().every((r) => r.getIsSelected())
     : undefined;
 
   const isChecked = selectAll
@@ -122,7 +127,8 @@ export const MRT_SelectCheckbox = <TData extends MRT_RowData>({
         <Checkbox
           indeterminate={
             !isChecked && selectAll
-              ? table.getIsSomeRowsSelected()
+              ? // Fix: getIsSomeRowsSelected() includes group rows, use leaf-only filter
+                getLeafRows().some((r) => r.getIsSelected())
               : row?.getIsSomeSelected() && row.getCanSelectSubRows()
           }
           {...commonProps}

--- a/packages/material-react-table/src/utils/row.utils.ts
+++ b/packages/material-react-table/src/utils/row.utils.ts
@@ -175,14 +175,17 @@ export const getMRT_RowSelectionHandler =
 
     const wasCurrentRowChecked = getIsRowSelected({ row, table });
 
-    // Fix: toggleSelected() on a group row also writes its own ID into rowSelection 
-    // Removing it, keeping only the leaf row IDs
+    // If this is a group row, toggle all its leaf sub-rows instead of itself
+    // to prevent the group row ID from entering rowSelection
     if (row.getIsGrouped()) {
-      table.setRowSelection((prev) => {
-        const next = { ...prev };
-        delete next[row.id];
-        return next;
+      const newValue = value ?? !wasCurrentRowChecked;
+      row.getLeafRows().forEach((leafRow) => {
+        if (leafRow.getCanSelect()) {
+          leafRow.toggleSelected(newValue);
+        }
       });
+      lastSelectedRowId.current = row.id;
+      return;
     }
 
     // toggle selection of this row

--- a/packages/material-react-table/src/utils/row.utils.ts
+++ b/packages/material-react-table/src/utils/row.utils.ts
@@ -175,6 +175,16 @@ export const getMRT_RowSelectionHandler =
 
     const wasCurrentRowChecked = getIsRowSelected({ row, table });
 
+    // Fix: toggleSelected() on a group row also writes its own ID into rowSelection 
+    // Removing it, keeping only the leaf row IDs
+    if (row.getIsGrouped()) {
+      table.setRowSelection((prev) => {
+        const next = { ...prev };
+        delete next[row.id];
+        return next;
+      });
+    }
+
     // toggle selection of this row
     row.toggleSelected(value ?? !wasCurrentRowChecked);
 
@@ -250,9 +260,17 @@ export const getMRT_SelectAllHandler =
       refs: { lastSelectedRowId },
     } = table;
 
-    selectAllMode === 'all' || forceAll
-      ? table.toggleAllRowsSelected(value ?? (event as any).target.checked)
-      : table.toggleAllPageRowsSelected(value ?? (event as any).target.checked);
+    // Fix: replaces toggleAllPageRowsSelected() / toggleAllRowsSelected() which
+    // include group rows in flatRows, causing group IDs to pollute rowSelection.
+    const checked = value ?? (event as any).target.checked;
+    const rows = (selectAllMode === 'all' || forceAll
+      ? table.getPrePaginationRowModel().flatRows
+      : table.getPaginationRowModel().flatRows
+    ).filter((row) => !row.getIsGrouped());
+    rows.forEach((row) => {
+      if (row.getCanSelect()) row.toggleSelected(checked);
+    });
+    
     if (enableRowPinning && rowPinningDisplayMode?.includes('select')) {
       table.setRowPinning({ bottom: [], top: [] });
     }

--- a/packages/material-react-table/stories/fixed-bugs/groupingRowselection.stories.tsx
+++ b/packages/material-react-table/stories/fixed-bugs/groupingRowselection.stories.tsx
@@ -1,0 +1,68 @@
+import { type MRT_ColumnDef, MaterialReactTable, useMaterialReactTable } from '../../src';
+import { faker } from '@faker-js/faker';
+import { type Meta } from '@storybook/react';
+
+const meta: Meta = {
+  title: 'Fixed Bugs/Grouping RowSelection',
+};
+
+export default meta;
+
+type Person = {
+  address: string;
+  city: string;
+  firstName: string;
+  lastName: string;
+  state: string;
+  gender: string;
+};
+
+const columns: MRT_ColumnDef<Person>[] = [
+  {
+    accessorKey: 'firstName',
+    header: 'First Name',
+  },
+  {
+    accessorKey: 'lastName',
+    header: 'Last Name',
+  },
+  {
+    accessorKey: 'address',
+    header: 'Address',
+  },
+  {
+    accessorKey: 'city',
+    header: 'City',
+  },
+  {
+    accessorKey: 'state',
+    header: 'State',
+  },
+  {
+    accessorKey: 'gender',
+    header: 'Gender',
+  },
+];
+
+const data = [...Array(300)].map(() => ({
+  address: faker.location.streetAddress(),
+  city: faker.location.city(),
+  firstName: faker.person.firstName(),
+  lastName: faker.person.lastName(),
+  state: faker.location.state(),
+  gender: ["Male", "Female"][faker.number.int({min: 0, max: 1})]
+}));
+
+export const GroupingRowSelection = () => {
+  const table = useMaterialReactTable({
+      columns,
+      data,
+      enableGrouping: true,
+      enableRowSelection: true,
+      initialState: {
+        grouping: ["gender"]
+      }
+  })
+  console.log(table.getState().rowSelection);
+  return <MaterialReactTable table={table} />
+};


### PR DESCRIPTION
Fixes #1226

## Problem
When grouping is active, selecting a group row (e.g. "gender:Male") causes
its synthetic ID to be written into `rowSelection` as a side effect of
TanStack's `toggleSelected()`.

## Changes
**`row.utils.ts`**
- `getMRT_RowSelectionHandler`: after `row.toggleSelected()`, remove the group
  row ID from `rowSelection` via `setRowSelection`, leaving only the leaf row
  IDs.
- `getMRT_SelectAllHandler`: replace `toggleAllPageRowsSelected()` /
  `toggleAllRowsSelected()` with a manual loop over `flatRows` filtered to
  leaf rows only.
  
  **`MRT_SelectCheckbox.tsx`**
- Replace `getIsAllPageRowsSelected()` / `getIsAllRowsSelected()` and
  `getIsSomeRowsSelected()` with leaf-only computations with `getIsGrouped()`,
  as all three native methods include group rows in their denominator.